### PR TITLE
Rebuild Figma UI around bespoke whitespace-forward components

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# card-based-info-base
-Trying to create a base for displaying information that makes sense to me.
+# Card-Based Information Repository
+
+This repository hosts multiple iterations of the CardSpoke / Card-Based Information Repository app. Legacy HTML exports for each historical release are kept at the repo root for archival purposes.
+
+The actively developed implementation lives under [`figma/`](figma/). It is a Vite + React rewrite that preserves the full feature set of the 0.7 release while adopting the refined CardSpoke visual design from Figma.
+
+## Project structure
+
+- `figma/` – Source for the new React client, including the runtime that powers extensions ("mods"), card storage helpers, and redesigned UI components.
+- `*.html` – Archived self-contained builds for previous versions of the app.
+- `Card-Based Information Repository.zip` – Original asset bundle exported from Figma (kept for reference).
+
+See [`figma/README.md`](figma/README.md) for setup and development instructions for the React client.

--- a/figma/README.md
+++ b/figma/README.md
@@ -1,0 +1,11 @@
+
+  # Card-Based Information Repository
+
+  This is a code bundle for Card-Based Information Repository. The original project is available at https://www.figma.com/design/UiB0PN16BmvBEfqXPASYD4/Card-Based-Information-Repository.
+
+  ## Running the code
+
+  Run `npm i` to install the dependencies.
+
+  Run `npm run dev` to start the development server.
+  

--- a/figma/index.html
+++ b/figma/index.html
@@ -1,0 +1,15 @@
+
+  <!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <title>Card-Based Information Repository</title>
+    </head>
+
+    <body>
+      <div id="root"></div>
+      <script type="module" src="/src/main.tsx"></script>
+    </body>
+  </html>
+  

--- a/figma/package.json
+++ b/figma/package.json
@@ -1,0 +1,22 @@
+
+  {
+      "name": "Card-Based Information Repository",
+      "version": "0.1.0",
+      "private": true,
+      "dependencies": {
+          "lucide-react": "^0.487.0",
+          "motion": "^11.11.0",
+          "react": "^18.3.1",
+          "react-dom": "^18.3.1",
+          "sonner": "^2.0.3"
+      },
+      "devDependencies": {
+          "@types/node": "^20.10.0",
+          "@vitejs/plugin-react-swc": "^3.10.2",
+          "vite": "6.3.5"
+      },
+      "scripts": {
+          "dev": "vite",
+          "build": "vite build"
+      }
+  }

--- a/figma/src/App.tsx
+++ b/figma/src/App.tsx
@@ -1,0 +1,763 @@
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { Toaster, toast } from "sonner";
+import { Header } from "./components/Header";
+import { SearchBar } from "./components/SearchBar";
+import { Breadcrumbs } from "./components/Breadcrumbs";
+import { CardListView, SortOption } from "./views/CardListView";
+import { CardDetailView } from "./views/CardDetailView";
+import { CardFormView, CardFormPayload } from "./views/CardFormView";
+import { SearchResultsView } from "./views/SearchResultsView";
+import { UploadModal } from "./components/UploadModal";
+import { ManageModsModal } from "./components/ManageModsModal";
+import {
+  AppendTXTResult,
+  Card,
+  CardID,
+  NavState,
+  PageName,
+  StoreShape
+} from "./lib/types";
+import {
+  cloneCard,
+  cloneStore,
+  createCard,
+  createEmptyStore,
+  deleteCard,
+  getInstanceNames,
+  importJSON,
+  importTXTOutline,
+  installModPackage,
+  loadStore,
+  removeMod,
+  saveStore,
+  searchCards,
+  setInstanceNames,
+  toggleMod,
+  updateCard,
+  validateImport,
+  appendTXTToDetails,
+  buildPackage,
+  exportTXT,
+  getModSummary
+} from "./lib/store";
+import { downloadJSON, downloadTXT } from "./lib/download";
+import { createModRuntime } from "./lib/modRuntime";
+
+const APP_EXPORT_VERSION = "0.7";
+
+const initialNav: NavState = {
+  page: "list",
+  cardId: null,
+  parentId: null,
+  searchQuery: ""
+};
+
+const sanitizeFilename = (value: string) =>
+  value
+    .replace(/[^a-z0-9_-]/gi, "-")
+    .replace(/-+/g, "-")
+    .substring(0, 50)
+    .toLowerCase();
+
+export default function App() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    if (typeof window === "undefined") return "light";
+    return (localStorage.getItem("nested_cards_theme") as 'light' | 'dark') || "light";
+  });
+  const [styleMode, setStyleMode] = useState<'classic' | 'minimal'>(() => {
+    if (typeof window === "undefined") return "classic";
+    return (localStorage.getItem("nested_cards_style") as 'classic' | 'minimal') || "classic";
+  });
+  const [store, setStore] = useState<StoreShape>(createEmptyStore());
+  const [instanceName, setInstanceName] = useState<string>("default");
+  const [instanceKey, setInstanceKey] = useState<string>("");
+  const [navState, setNavState] = useState<NavState>(initialNav);
+  const [sortOrder, setSortOrder] = useState<SortOption>("alpha");
+  const [searchInput, setSearchInput] = useState("");
+  const [searchQuery, setSearchQuery] = useState("");
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [uploadLocation, setUploadLocation] = useState<CardID | "root">("root");
+  const [modsOpen, setModsOpen] = useState(false);
+  const [dirty, setDirty] = useState(false);
+
+  const historyRef = useRef<NavState[]>([]);
+  const storeRef = useRef(store);
+  const navRef = useRef(navState);
+
+  useEffect(() => {
+    storeRef.current = store;
+  }, [store]);
+  useEffect(() => {
+    navRef.current = navState;
+  }, [navState]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("light", theme === "light");
+    localStorage.setItem("nested_cards_theme", theme);
+  }, [theme]);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("minimal", styleMode === "minimal");
+    localStorage.setItem("nested_cards_style", styleMode);
+  }, [styleMode]);
+
+  useEffect(() => {
+    const instances = getInstanceNames();
+    let selected = instances[0] || "default";
+    if (!instances.includes(selected)) {
+      setInstanceNames([...instances, selected]);
+    }
+    setInstanceName(selected);
+    const key = selected ? `nested_cards_store__${selected}` : "nested_cards_store";
+    setInstanceKey(key);
+    const loaded = cloneStore(loadStore(key));
+    setStore(loaded);
+    historyRef.current = [];
+    setNavState(initialNav);
+  }, []);
+
+  useEffect(() => {
+    if (dirty && instanceKey) {
+      saveStore(store, instanceKey);
+      setDirty(false);
+    }
+  }, [store, dirty, instanceKey]);
+
+  const goTo = useCallback(
+    (page: PageName, options: Partial<NavState> = {}, extra: { pushHistory?: boolean } = {}) => {
+      setNavState((prev) => {
+        if (extra.pushHistory !== false) {
+          historyRef.current.push(prev);
+        }
+        const next: NavState = {
+          page,
+          cardId: prev.cardId,
+          parentId: prev.parentId,
+          searchQuery: prev.searchQuery
+        };
+        if (page === "list") {
+          next.cardId = options.cardId ?? null;
+          next.parentId = options.cardId ?? null;
+          next.searchQuery = "";
+        } else if (page === "read") {
+          const targetId = options.cardId ?? prev.cardId ?? null;
+          next.cardId = targetId;
+          const card = targetId ? storeRef.current.cards[targetId] : null;
+          next.parentId = options.parentId ?? card?.parentId ?? null;
+          next.searchQuery = "";
+        } else if (page === "edit") {
+          next.cardId = options.cardId ?? null;
+          if (options.parentId !== undefined) {
+            next.parentId = options.parentId;
+          } else if (options.cardId) {
+            const card = storeRef.current.cards[options.cardId];
+            next.parentId = card?.parentId ?? null;
+          } else {
+            next.parentId = options.parentId ?? null;
+          }
+          next.searchQuery = "";
+        } else if (page === "search") {
+          next.cardId = null;
+          next.parentId = null;
+          next.searchQuery = options.searchQuery ?? prev.searchQuery;
+        }
+        return next;
+      });
+    },
+    []
+  );
+
+  const goBack = useCallback(() => {
+    setNavState((prev) => {
+      const history = historyRef.current;
+      if (history.length === 0) return prev;
+      const next = history.pop();
+      return next ?? prev;
+    });
+  }, []);
+
+  const runtimeRef = useRef(
+    createModRuntime({
+      getStore: () => storeRef.current,
+      getNavState: () => navRef.current,
+      navigate: (page: PageName, options: Partial<NavState> = {}) => goTo(page, options),
+      showToast: (message: string, type: "success" | "error" = "success") => {
+        if (type === "error") toast.error(message);
+        else toast.success(message);
+      },
+      markDirty: () => setDirty(true)
+    })
+  );
+
+  useEffect(() => {
+    runtimeRef.current.syncFromStore(store);
+    runtimeRef.current.runHook("onAppInit");
+  }, [store]);
+
+  const chooseInstance = useCallback(() => {
+    const existing = getInstanceNames();
+    const defaultName = instanceName || existing[0] || "default";
+    const promptValue = typeof window !== "undefined" ? window.prompt(
+      existing.length
+        ? `Enter a data instance name (existing: ${existing.join(", ")}) or type a new one:`
+        : "Enter a name for your data instance:",
+      defaultName
+    ) : null;
+    if (promptValue === null) return;
+    const selected = (promptValue.trim() || "default").toLowerCase();
+    if (!existing.includes(selected)) {
+      setInstanceNames([...existing, selected]);
+    }
+    const key = `nested_cards_store__${selected}`;
+    setInstanceName(selected);
+    setInstanceKey(key);
+    const loaded = cloneStore(loadStore(key));
+    setStore(loaded);
+    historyRef.current = [];
+    setNavState(initialNav);
+    runtimeRef.current.syncFromStore(loaded);
+    runtimeRef.current.runHook("onAppInit");
+    toast.success(`Switched to instance ${selected}.`);
+  }, [instanceName]);
+
+  const handleCardRender = useCallback((cardId: CardID, element: HTMLElement | null) => {
+    if (!cardId) return;
+    const card = cloneCard(storeRef.current.cards[cardId]);
+    if (!card) return;
+    runtimeRef.current.runHook("onCardRender", card, element);
+  }, []);
+
+  const handleCardFormSubmit = useCallback(
+    (payload: CardFormPayload) => {
+      const editingId = navRef.current.cardId;
+      const cardsToNotify: { card: Card; context: Record<string, unknown> }[] = [];
+      if (navRef.current.page === "edit" && editingId) {
+        setStore((prev) => {
+          const next = cloneStore(prev);
+          const updated = updateCard(next, editingId, {
+            title: payload.title,
+            body: payload.body,
+            parentId: payload.parentId
+          });
+          if (updated) {
+            payload.removedChildren.forEach((childId) => {
+              const removed = cloneCard(next.cards[childId]);
+              if (removed) {
+                runtimeRef.current.runHook("onCardDelete", removed, { source: "edit" });
+              }
+              deleteCard(next, childId);
+            });
+            Object.entries(payload.renamedChildren).forEach(([childId, title]) => {
+              if (!payload.removedChildren.includes(childId) && next.cards[childId]) {
+                updateCard(next, childId, { title });
+              }
+            });
+            payload.newChildren.forEach((title) => {
+              const child = createCard(next, title, "", editingId);
+              const cloned = cloneCard(next.cards[child.id]);
+              if (cloned) {
+                cardsToNotify.push({ card: cloned, context: { isNew: true, source: "addChild" } });
+              }
+            });
+            const finalCard = cloneCard(next.cards[editingId]);
+            if (finalCard) {
+              cardsToNotify.push({ card: finalCard, context: { isNew: false, source: "updateCard" } });
+            }
+          }
+          setDirty(true);
+          return next;
+        });
+        cardsToNotify.forEach(({ card, context }) => runtimeRef.current.runHook("onCardSave", card, context));
+        toast.success("Card updated.");
+        goTo("read", { cardId: editingId }, { pushHistory: false });
+      } else {
+        let createdId: CardID | null = null;
+        setStore((prev) => {
+          const next = cloneStore(prev);
+          const created = createCard(next, payload.title, payload.body, payload.parentId);
+          createdId = created.id;
+          const main = cloneCard(next.cards[created.id]);
+          if (main) {
+            cardsToNotify.push({ card: main, context: { isNew: true, source: "createCard" } });
+          }
+          payload.newChildren.forEach((title) => {
+            const child = createCard(next, title, "", created.id);
+            const cloned = cloneCard(next.cards[child.id]);
+            if (cloned) {
+              cardsToNotify.push({ card: cloned, context: { isNew: true, source: "addChild" } });
+            }
+          });
+          setDirty(true);
+          return next;
+        });
+        cardsToNotify.forEach(({ card, context }) => runtimeRef.current.runHook("onCardSave", card, context));
+        if (createdId) {
+          toast.success("Card created.");
+          goTo("read", { cardId: createdId }, { pushHistory: false });
+        } else {
+          toast.error("Unable to create card.");
+        }
+      }
+    },
+    [goTo]
+  );
+
+  const handleDeleteCard = useCallback(
+    (cardId: CardID) => {
+      const card = cloneCard(storeRef.current.cards[cardId]);
+      if (!card) return;
+      if (typeof window !== "undefined" && !window.confirm("Delete this card and all its children?")) {
+        return;
+      }
+      setStore((prev) => {
+        const next = cloneStore(prev);
+        deleteCard(next, cardId);
+        setDirty(true);
+        return next;
+      });
+      runtimeRef.current.runHook("onCardDelete", card, { source: "deleteCard" });
+      toast.success("Card deleted.");
+      goTo("list", { cardId: card.parentId ?? null }, { pushHistory: false });
+    },
+    [goTo]
+  );
+
+  const handleSearch = useCallback(
+    (query: string) => {
+      const trimmed = query.trim();
+      if (!trimmed) {
+        setSearchQuery("");
+        setNavState(initialNav);
+        return;
+      }
+      setSearchQuery(trimmed);
+      goTo("search", { searchQuery: trimmed });
+    },
+    [goTo]
+  );
+
+  const searchResults = useMemo(() => {
+    if (!searchQuery) return [] as Card[];
+    return searchCards(store, searchQuery);
+  }, [store, searchQuery]);
+
+  const handleExport = useCallback(
+    (exportType: string, cardId?: CardID | null) => {
+      if (exportType === "mods-json") {
+        const activeMods: Record<string, unknown> = {};
+        Object.entries(store.mods || {}).forEach(([modId, modData]) => {
+          if (modData?.enabled) {
+            activeMods[modId] = {
+              js: modData.js || "",
+              css: modData.css || "",
+              meta: modData.meta ? { ...modData.meta } : {}
+            };
+          }
+        });
+        const filename = `active-mods-${new Date().toISOString().split("T")[0]}.json`;
+        downloadJSON(filename, activeMods);
+        toast.success("Exported active extensions.");
+        return;
+      }
+
+      let rootIds: CardID[] = [];
+      let filename = "";
+      if (exportType.startsWith("instance")) {
+        rootIds = store.rootOrder;
+        const date = new Date().toISOString().split("T")[0];
+        filename = exportType.endsWith("txt")
+          ? `card-info-base-instance-${date}.txt`
+          : `card-info-base-instance-${date}.json`;
+      } else if (cardId) {
+        const card = store.cards[cardId];
+        const slug = sanitizeFilename(card?.title || "card");
+        rootIds = [cardId];
+        filename = exportType.endsWith("txt")
+          ? `${slug}-${exportType.startsWith("subtree") ? "subtree" : "card"}.txt`
+          : `${slug}-${exportType.startsWith("subtree") ? "subtree" : "card"}.json`;
+      } else {
+        toast.error("Please select a card to export.");
+        return;
+      }
+
+      if (exportType.endsWith("txt")) {
+        const text = exportTXT(store, exportType.startsWith("instance") ? store.rootOrder : rootIds);
+        downloadTXT(filename, text);
+      } else {
+        const pkg = buildPackage(store, rootIds, exportType.startsWith("instance") ? "instance" : exportType.startsWith("subtree") ? "subtree" : "card");
+        pkg.version = APP_EXPORT_VERSION;
+        downloadJSON(filename, pkg);
+      }
+      toast.success("Download started.");
+    },
+    [store]
+  );
+
+  const readFileText = (file: File) => file.text();
+
+  const handleImportJSON = useCallback(
+    async (file: File, location: CardID | "root") => {
+      try {
+        const raw = await readFileText(file);
+        const pkg = JSON.parse(raw);
+        const validation = validateImport(pkg);
+        if (!validation.valid) {
+          toast.error(validation.error || "Invalid package");
+          return;
+        }
+        const placements: { card: Card; context: Record<string, unknown> }[] = [];
+        setStore((prev) => {
+          const next = cloneStore(prev);
+          const result = importJSON(next, pkg, location === "root" ? "root" : location);
+          result.importedIds.forEach((id) => {
+            const cloned = cloneCard(next.cards[id]);
+            if (cloned) {
+              placements.push({ card: cloned, context: { isNew: true, source: "importJSON", exportType: pkg.exportType } });
+            }
+          });
+          setDirty(true);
+          return next;
+        });
+        placements.forEach(({ card, context }) => runtimeRef.current.runHook("onCardSave", card, context));
+        toast.success(`Imported ${placements.length} cards.`);
+        if (location === "root") {
+          goTo("list", { cardId: null }, { pushHistory: false });
+        } else {
+          goTo("list", { cardId: location }, { pushHistory: false });
+        }
+        setUploadOpen(false);
+      } catch (error: any) {
+        toast.error(`Import failed: ${error?.message || error}`);
+      }
+    },
+    [goTo]
+  );
+
+  const handleImportTXT = useCallback(
+    async (file: File, mode: "outline" | "append", location: CardID | "root") => {
+      try {
+        const text = await readFileText(file);
+        if (mode === "outline") {
+          const parent = location === "root" ? null : location;
+          const created: Card[] = [];
+          setStore((prev) => {
+            const next = cloneStore(prev);
+            const result = importTXTOutline(next, text, parent);
+            result.rootIds.forEach((id) => {
+              const cloned = cloneCard(next.cards[id]);
+              if (cloned) {
+                created.push(cloned);
+              }
+            });
+            setDirty(true);
+            return next;
+          });
+          created.forEach((card) => runtimeRef.current.runHook("onCardSave", card, { isNew: true, source: "importTXT" }));
+          toast.success(`Imported ${created.length} cards.`);
+          goTo("list", { cardId: parent }, { pushHistory: false });
+        } else {
+          if (location === "root") {
+            toast.error("Select a specific card to append text to.");
+            return;
+          }
+          let result: AppendTXTResult | null = null;
+          setStore((prev) => {
+            const next = cloneStore(prev);
+            result = appendTXTToDetails(next, location, text);
+            if (result.success) {
+              setDirty(true);
+            }
+            return next;
+          });
+          if (result?.success) {
+            const updated = cloneCard(storeRef.current.cards[location]);
+            if (updated) {
+              runtimeRef.current.runHook("onCardSave", updated, { isNew: false, source: "appendTXT" });
+            }
+            toast.success("Text appended to card.");
+            goTo("read", { cardId: location }, { pushHistory: false });
+          } else {
+            toast.error(result?.error || "Unable to append text.");
+          }
+        }
+        setUploadOpen(false);
+      } catch (error: any) {
+        toast.error(`Import failed: ${error?.message || error}`);
+      }
+    },
+    [goTo]
+  );
+
+  const handleInstallModFile = useCallback(
+    async (file: File) => {
+      try {
+        const raw = await readFileText(file);
+        const pkg = JSON.parse(raw);
+        const preview = cloneStore(storeRef.current);
+        const result = installModPackage(preview, pkg, "upload");
+        if (!result.success) {
+          if (!result.cancelled) toast.error(result.error || "Failed to install extension");
+          return;
+        }
+        setStore(preview);
+        setDirty(true);
+        setUploadOpen(false);
+        toast.success(`Installed extension ${result.modId}.`);
+        setModsOpen(true);
+      } catch (error: any) {
+        toast.error(`Failed to install extension: ${error?.message || error}`);
+      }
+    },
+    []
+  );
+
+  const handleInstallModCode = useCallback(
+    (payload: { modId: string; name: string; version: string; author: string; js: string; css: string; enabled: boolean }) => {
+      if (!payload.modId || !payload.js.trim()) {
+        toast.error("Extension ID and JavaScript are required.");
+        return;
+      }
+      const modPackage = {
+        id: payload.modId,
+        meta: {
+          name: payload.name,
+          version: payload.version,
+          author: payload.author
+        },
+        js: payload.js,
+        css: payload.css,
+        enabled: payload.enabled
+      };
+      const preview = cloneStore(storeRef.current);
+      const result = installModPackage(preview, modPackage, "manual");
+      if (!result.success) {
+        if (!result.cancelled) toast.error(result.error || "Failed to install extension");
+        return;
+      }
+      setStore(preview);
+      setDirty(true);
+      setUploadOpen(false);
+      toast.success(`Installed extension ${payload.modId}.`);
+      setModsOpen(true);
+    },
+    []
+  );
+
+  const handleToggleMod = useCallback(
+    (modId: string) => {
+      setStore((prev) => {
+        const next = cloneStore(prev);
+        const mod = toggleMod(next, modId);
+        if (mod) {
+          const summary = getModSummary(modId, mod);
+          toast.success(`${summary.title} ${mod.enabled ? "enabled" : "disabled"}.`);
+          setDirty(true);
+        }
+        return next;
+      });
+    },
+    []
+  );
+
+  const openUploadModal = useCallback(() => {
+    const current = navRef.current;
+    if (current.page === "read" && current.cardId) {
+      setUploadLocation(current.cardId);
+    } else {
+      setUploadLocation("root");
+    }
+    setUploadOpen(true);
+  }, []);
+
+  const openManageMods = useCallback(() => setModsOpen(true), []);
+
+  const startNewCard = useCallback(() => {
+    goTo("edit", { cardId: null, parentId: null });
+  }, [goTo]);
+
+  const handleRemoveMod = useCallback((modId: string) => {
+    if (typeof window !== "undefined" && !window.confirm("Remove this extension permanently?")) {
+      return;
+    }
+    setStore((prev) => {
+      const next = cloneStore(prev);
+      const summary = getModSummary(modId, next.mods[modId]);
+      if (removeMod(next, modId)) {
+        toast.success(`${summary.title} removed.`);
+        setDirty(true);
+      }
+      return next;
+    });
+  }, []);
+
+  const breadcrumbTarget = useMemo(() => {
+    if (navState.page === "list") return navState.cardId;
+    if (navState.page === "read" || navState.page === "edit") return navState.cardId;
+    return null;
+  }, [navState]);
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Toaster />
+      <Header
+        theme={theme}
+        styleMode={styleMode}
+        onThemeToggle={() => setTheme((prev) => (prev === "light" ? "dark" : "light"))}
+        onStyleToggle={() => setStyleMode((prev) => (prev === "classic" ? "minimal" : "classic"))}
+        onHome={() => goTo("list", { cardId: null })}
+        onBack={goBack}
+        onAddCard={startNewCard}
+        onUpload={openUploadModal}
+        onManageMods={openManageMods}
+        onInstance={chooseInstance}
+        onExport={(type) => handleExport(type)}
+      />
+
+      <main className="mx-auto max-w-6xl px-6 pb-32 md:px-16">
+        <section className="mb-16 mt-6 grid gap-3 md:grid-cols-2 lg:grid-cols-4">
+          <ButtonBlock label="New Card" description="Start fresh at the top level" onClick={startNewCard} />
+          <ButtonBlock
+            label="Upload"
+            description="Import JSON or TXT content"
+            onClick={openUploadModal}
+          />
+          <ButtonBlock
+            label="Manage Extensions"
+            description="Enable, disable, or remove mods"
+            onClick={openManageMods}
+          />
+          <ButtonBlock
+            label="Switch Instance"
+            description="Jump between data workspaces"
+            onClick={chooseInstance}
+          />
+        </section>
+
+        <Breadcrumbs
+          store={store}
+          currentCardId={breadcrumbTarget}
+          onNavigate={(cardId) => goTo("list", { cardId })}
+        />
+
+        {navState.page === "list" && (
+          <CardListView
+            store={store}
+            parentId={navState.cardId}
+            sort={sortOrder}
+            onSortChange={setSortOrder}
+            onOpenCard={(id) => goTo("read", { cardId: id })}
+            onViewChildren={(id) => goTo("list", { cardId: id })}
+            onAddCardHere={(parent) => goTo("edit", { cardId: null, parentId: parent })}
+            onAddChild={(id) => goTo("edit", { cardId: null, parentId: id })}
+            onExport={(id, type) => handleExport(type, id)}
+            onCardRender={handleCardRender}
+          />
+        )}
+
+        {navState.page === "read" && navState.cardId && (
+          <CardDetailView
+            store={store}
+            cardId={navState.cardId}
+            onEdit={(id) => goTo("edit", { cardId: id })}
+            onAddChild={(id) => goTo("edit", { cardId: null, parentId: id })}
+            onViewChildren={(id) => goTo("list", { cardId: id })}
+            onViewParent={(id) => goTo("list", { cardId: id })}
+            onOpenCard={(id) => goTo("read", { cardId: id })}
+            onExport={(id, type) => handleExport(type, id)}
+            onUploadToCard={(id) => {
+              setUploadLocation(id);
+              setUploadOpen(true);
+            }}
+            onCardRender={handleCardRender}
+          />
+        )}
+
+        {navState.page === "edit" && (
+          <CardFormView
+            store={store}
+            cardId={navState.cardId}
+            parentId={navState.parentId}
+            onSubmit={handleCardFormSubmit}
+            onCancel={() => goBack()}
+            onDelete={navState.cardId ? handleDeleteCard : undefined}
+          />
+        )}
+
+        {navState.page === "search" && (
+          <SearchResultsView
+            query={searchQuery}
+            results={searchResults}
+            onOpenCard={(id) => goTo("read", { cardId: id })}
+            onCardRender={handleCardRender}
+          />
+        )}
+
+        <section className="mt-24 space-y-6">
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              handleSearch(searchInput);
+            }}
+          >
+            <SearchBar
+              value={searchInput}
+              onChange={setSearchInput}
+              placeholder="Search cards, tags, or content..."
+            />
+          </form>
+          <div className="flex gap-3">
+            <button
+              type="button"
+              className="text-sm text-muted-foreground underline"
+              onClick={() => {
+                setSearchInput("");
+                setSearchQuery("");
+                setNavState(initialNav);
+              }}
+            >
+              Clear Search
+            </button>
+          </div>
+        </section>
+      </main>
+
+      <UploadModal
+        open={uploadOpen}
+        onOpenChange={setUploadOpen}
+        store={store}
+        initialLocation={uploadLocation}
+        onImportJSON={handleImportJSON}
+        onImportTXT={handleImportTXT}
+        onInstallModFile={handleInstallModFile}
+        onInstallModCode={handleInstallModCode}
+      />
+
+      <ManageModsModal
+        open={modsOpen}
+        onOpenChange={setModsOpen}
+        store={store}
+        onToggleMod={handleToggleMod}
+        onRemoveMod={handleRemoveMod}
+      />
+    </div>
+  );
+}
+
+interface ButtonBlockProps {
+  label: string;
+  description: string;
+  onClick: () => void;
+}
+
+function ButtonBlock({ label, description, onClick }: ButtonBlockProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex h-full flex-col justify-between rounded-[32px] bg-card px-7 py-8 text-left shadow-[0_30px_80px_rgba(17,17,17,0.08)] transition hover:-translate-y-1 hover:shadow-[0_40px_120px_rgba(17,17,17,0.12)]"
+    >
+      <span className="text-lg font-medium text-foreground">{label}</span>
+      <span className="mt-3 text-sm text-muted-foreground">{description}</span>
+    </button>
+  );
+}

--- a/figma/src/Attributions.md
+++ b/figma/src/Attributions.md
@@ -1,0 +1,3 @@
+Earlier iterations of this project incorporated components from [shadcn/ui](https://ui.shadcn.com/) under the [MIT license](https://github.com/shadcn-ui/ui/blob/main/LICENSE.md). The current build replaces them with bespoke primitives styled to match the provided Figma reference.
+
+This Figma Make file includes photos from [Unsplash](https://unsplash.com) used under [license](https://unsplash.com/license).

--- a/figma/src/components/Breadcrumbs.tsx
+++ b/figma/src/components/Breadcrumbs.tsx
@@ -1,0 +1,38 @@
+import { Fragment } from "react";
+import { CardID, StoreShape } from "../lib/types";
+import { cardPath } from "../lib/store";
+
+interface BreadcrumbsProps {
+  store: StoreShape;
+  currentCardId: CardID | null;
+  onNavigate: (cardId: CardID | null) => void;
+}
+
+export function Breadcrumbs({ store, currentCardId, onNavigate }: BreadcrumbsProps) {
+  const path = cardPath(store, currentCardId);
+  const items = path.map((id) => store.cards[id]).filter(Boolean);
+
+  return (
+    <nav className="text-sm text-muted-foreground mb-10" aria-label="Breadcrumb">
+      <button
+        type="button"
+        className="hover:text-foreground transition-colors"
+        onClick={() => onNavigate(null)}
+      >
+        Home
+      </button>
+      {items.map((card, index) => (
+        <Fragment key={card!.id}>
+          <span className="mx-2 text-muted-foreground">/</span>
+          <button
+            type="button"
+            onClick={() => onNavigate(card!.id)}
+            className={`transition-colors ${index === items.length - 1 ? "text-foreground" : "hover:text-foreground"}`}
+          >
+            {card!.title || "(Untitled)"}
+          </button>
+        </Fragment>
+      ))}
+    </nav>
+  );
+}

--- a/figma/src/components/CategoryFilter.tsx
+++ b/figma/src/components/CategoryFilter.tsx
@@ -1,0 +1,44 @@
+import { motion } from "motion/react";
+
+interface CategoryFilterProps {
+  categories: string[];
+  selectedCategory: string | null;
+  onSelectCategory: (category: string | null) => void;
+}
+
+export function CategoryFilter({ categories, selectedCategory, onSelectCategory }: CategoryFilterProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.5, delay: 0.1 }}
+      className="flex flex-wrap gap-3"
+    >
+      <button
+        onClick={() => onSelectCategory(null)}
+        className={`px-5 py-2 rounded-full border transition-all duration-300 ${
+          selectedCategory === null
+            ? 'bg-foreground text-background border-foreground'
+            : 'bg-transparent text-muted-foreground border-border hover:border-foreground hover:text-foreground'
+        }`}
+        style={{ fontSize: '14px', fontWeight: 300 }}
+      >
+        All
+      </button>
+      {categories.map((category) => (
+        <button
+          key={category}
+          onClick={() => onSelectCategory(category)}
+          className={`px-5 py-2 rounded-full border transition-all duration-300 ${
+            selectedCategory === category
+              ? 'bg-foreground text-background border-foreground'
+              : 'bg-transparent text-muted-foreground border-border hover:border-foreground hover:text-foreground'
+          }`}
+          style={{ fontSize: '14px', fontWeight: 300 }}
+        >
+          {category}
+        </button>
+      ))}
+    </motion.div>
+  );
+}

--- a/figma/src/components/Header.tsx
+++ b/figma/src/components/Header.tsx
@@ -1,0 +1,110 @@
+import { Home, Moon, Sun, Menu, ArrowLeft, Sparkles } from "lucide-react";
+import { Button } from "./ui/button";
+import { motion } from "motion/react";
+import { SimpleMenu, SimpleMenuItem } from "./SimpleMenu";
+
+interface HeaderProps {
+  theme: 'light' | 'dark';
+  styleMode: 'classic' | 'minimal';
+  onThemeToggle: () => void;
+  onStyleToggle: () => void;
+  onHome: () => void;
+  onBack: () => void;
+  onAddCard: () => void;
+  onUpload: () => void;
+  onManageMods: () => void;
+  onInstance: () => void;
+  onExport: (type: string) => void;
+}
+
+const exportMenuItems = [
+  { label: "Instance (JSON)", value: "instance-json" },
+  { label: "Instance (TXT)", value: "instance-txt" },
+  { label: "Active Extensions (JSON)", value: "mods-json" }
+];
+
+export function Header({
+  theme,
+  styleMode,
+  onThemeToggle,
+  onStyleToggle,
+  onHome,
+  onBack,
+  onAddCard,
+  onUpload,
+  onManageMods,
+  onInstance,
+  onExport
+}: HeaderProps) {
+  const menuItems: SimpleMenuItem[] = [
+    { label: "New Card", onSelect: onAddCard },
+    { label: "Upload Content", onSelect: onUpload },
+    { label: "Manage Extensions", onSelect: onManageMods },
+    { label: "Switch Instance", onSelect: onInstance },
+    { label: styleMode === 'minimal' ? 'Style · Minimal' : 'Style · Classic', disabled: true },
+    ...exportMenuItems.map((item) => ({ label: item.label, onSelect: () => onExport(item.value) }))
+  ];
+
+  return (
+    <motion.header
+      initial={{ opacity: 0, y: -16 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.7, ease: [0.16, 1, 0.3, 1] }}
+      className="bg-background"
+    >
+      <div
+        className="mx-auto max-w-6xl px-6 pb-12 md:px-16"
+        style={{ paddingTop: "6rem" }}
+      >
+        <div className="flex flex-col gap-10 md:flex-row md:items-start md:justify-between">
+          <div className="max-w-xl space-y-6">
+            <h1
+              className="text-[64px] font-semibold leading-[0.95] tracking-tight text-foreground"
+              style={{ fontFamily: "'Inter', 'Outfit', sans-serif" }}
+            >
+              CardSpoke
+            </h1>
+            <p className="text-lg leading-relaxed text-muted-foreground">
+              A calm workspace for thinking in connected cards. Outline ideas, expand details, and resurface knowledge without losing the thread.
+            </p>
+            <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground/80">
+              <span className="uppercase tracking-[0.3em]">Style · {styleMode === "minimal" ? "Minimal" : "Classic"}</span>
+              <span className="uppercase tracking-[0.3em]">Theme · {theme === "light" ? "Day" : "Night"}</span>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3 md:justify-end">
+            <Button
+              variant="secondary"
+              size="icon"
+              onClick={onHome}
+              aria-label="Go home"
+            >
+              <Home className="h-5 w-5" strokeWidth={1.4} />
+            </Button>
+            <Button variant="ghost" size="icon" onClick={onBack} aria-label="Go back">
+              <ArrowLeft className="h-5 w-5" strokeWidth={1.4} />
+            </Button>
+            <Button variant="ghost" size="icon" onClick={onThemeToggle} aria-label="Toggle theme">
+              {theme === "light" ? (
+                <Moon className="h-5 w-5" strokeWidth={1.4} />
+              ) : (
+                <Sun className="h-5 w-5" strokeWidth={1.4} />
+              )}
+            </Button>
+            <Button variant="ghost" size="icon" onClick={onStyleToggle} aria-label="Toggle style">
+              <Sparkles className="h-5 w-5" strokeWidth={1.4} />
+            </Button>
+            <SimpleMenu
+              triggerIcon={<Menu className="h-5 w-5" strokeWidth={1.4} />}
+              triggerLabel="Open primary menu"
+              items={menuItems}
+              triggerClassName="h-12 w-12 rounded-full bg-foreground text-background hover:bg-foreground/90"
+              menuClassName="backdrop-blur-lg"
+            />
+          </div>
+        </div>
+      </div>
+    </motion.header>
+  );
+}

--- a/figma/src/components/InfoCard.tsx
+++ b/figma/src/components/InfoCard.tsx
@@ -1,0 +1,65 @@
+import { motion } from "motion/react";
+import { ReactNode, forwardRef } from "react";
+
+interface InfoCardProps {
+  title: string;
+  preview: string;
+  tags?: string[];
+  childrenCount?: number;
+  subtitle?: string;
+  meta?: string;
+  onClick?: () => void;
+  actions?: ReactNode;
+}
+
+export const InfoCard = forwardRef<HTMLDivElement, InfoCardProps>(function InfoCard(
+  { title, preview, tags = [], childrenCount, subtitle, meta, onClick, actions }: InfoCardProps,
+  ref
+) {
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 12 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] }}
+      className="group relative mb-12 overflow-hidden rounded-[40px] bg-card/95 px-10 py-12 text-foreground shadow-[0_36px_80px_rgba(17,17,17,0.08)] transition duration-500 hover:-translate-y-1 hover:shadow-[0_48px_120px_rgba(17,17,17,0.14)]"
+      onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      ref={ref}
+    >
+      {typeof childrenCount === "number" && (
+        <span
+          aria-hidden
+          className="pointer-events-none absolute right-12 top-8 text-[84px] font-light leading-none text-muted-foreground/20 transition group-hover:text-muted-foreground/30"
+          style={{ fontFamily: "Outfit, sans-serif", letterSpacing: "-0.04em" }}
+        >
+          {childrenCount}
+        </span>
+      )}
+
+      <div className="relative z-10 space-y-6">
+        <div className="space-y-2">
+          <h3 className="text-3xl font-semibold tracking-tight text-foreground transition-opacity duration-500 group-hover:opacity-80">
+            {title || "(Untitled)"}
+          </h3>
+          {subtitle && <p className="text-sm uppercase tracking-[0.2em] text-muted-foreground">{subtitle}</p>}
+          {meta && <span className="text-xs uppercase tracking-[0.3em] text-muted-foreground">{meta}</span>}
+        </div>
+
+        <p className="max-w-2xl text-lg leading-relaxed text-muted-foreground">{preview}</p>
+
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-2 text-xs uppercase tracking-[0.3em] text-muted-foreground">
+            {tags.map((tag) => (
+              <span key={tag} className="rounded-full bg-foreground/5 px-4 py-1 text-foreground/70">
+                #{tag.toLowerCase()}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {actions && <div className="pt-4">{actions}</div>}
+      </div>
+    </motion.article>
+  );
+});

--- a/figma/src/components/ManageModsModal.tsx
+++ b/figma/src/components/ManageModsModal.tsx
@@ -1,0 +1,59 @@
+import { Modal } from "./Modal";
+import { Button } from "./ui/button";
+import { StoreShape } from "../lib/types";
+import { getModSummary } from "../lib/store";
+
+interface ManageModsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  store: StoreShape;
+  onToggleMod: (modId: string) => void;
+  onRemoveMod: (modId: string) => void;
+}
+
+export function ManageModsModal({ open, onOpenChange, store, onToggleMod, onRemoveMod }: ManageModsModalProps) {
+  const mods = Object.entries(store.mods || {}).sort((a, b) => a[0].localeCompare(b[0]));
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange} title="Manage Extensions" className="max-w-2xl">
+      {mods.length === 0 ? (
+        <div className="rounded-[28px] bg-muted/20 px-8 py-16 text-center text-muted-foreground">
+          No extensions installed yet.
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {mods.map(([modId, mod]) => {
+            const summary = getModSummary(modId, mod);
+            return (
+              <div
+                key={modId}
+                className={
+                  "flex flex-wrap items-center justify-between gap-4 rounded-[28px] bg-muted/15 p-6 shadow-[0_24px_60px_rgba(17,17,17,0.08)]"
+                }
+                style={{ opacity: mod.enabled ? 1 : 0.6 }}
+              >
+                <div className="space-y-1">
+                  <div className="text-base font-medium text-foreground">{summary.title}</div>
+                  {summary.subtitle && (
+                    <div className="text-xs uppercase tracking-[0.3em] text-muted-foreground">{summary.subtitle}</div>
+                  )}
+                  {summary.description && (
+                    <div className="text-sm leading-relaxed text-muted-foreground">{summary.description}</div>
+                  )}
+                </div>
+                <div className="flex gap-3">
+                  <Button variant="secondary" onClick={() => onToggleMod(modId)}>
+                    {mod.enabled ? "Disable" : "Enable"}
+                  </Button>
+                  <Button variant="destructive" onClick={() => onRemoveMod(modId)}>
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/figma/src/components/Modal.tsx
+++ b/figma/src/components/Modal.tsx
@@ -1,0 +1,70 @@
+import { ReactNode, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { cn } from "./cn";
+
+interface ModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+export function Modal({ open, onOpenChange, title, className, children }: ModalProps) {
+  const [mountNode, setMountNode] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (typeof document !== "undefined") {
+      setMountNode(document.body);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open || typeof document === "undefined") return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onOpenChange(false);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open, onOpenChange]);
+
+  if (!open || !mountNode) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-10">
+      <div
+        className="absolute inset-0 bg-foreground/10 backdrop-blur-sm"
+        onClick={() => onOpenChange(false)}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={cn(
+          "relative z-10 max-h-[90vh] w-full max-w-3xl overflow-y-auto rounded-[36px] bg-background/95 p-8 shadow-[0_40px_120px_rgba(17,17,17,0.18)]",
+          className
+        )}
+      >
+        {title && <h2 className="text-2xl font-semibold text-foreground">{title}</h2>}
+        <button
+          type="button"
+          className="absolute right-6 top-6 inline-flex h-9 w-9 items-center justify-center rounded-full bg-foreground/10 text-foreground transition hover:bg-foreground/20"
+          onClick={() => onOpenChange(false)}
+          aria-label="Close dialog"
+        >
+          ×
+        </button>
+        <div className="mt-6 space-y-6 text-foreground">{children}</div>
+      </div>
+    </div>,
+    mountNode
+  );
+}

--- a/figma/src/components/SearchBar.tsx
+++ b/figma/src/components/SearchBar.tsx
@@ -1,0 +1,28 @@
+import { Search } from "lucide-react";
+import { motion } from "motion/react";
+
+interface SearchBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export function SearchBar({ value, onChange, placeholder = "Search repository..." }: SearchBarProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.6 }}
+      className="relative"
+    >
+      <Search className="absolute left-6 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" strokeWidth={1.4} />
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full rounded-full bg-muted/25 pl-16 pr-6 py-5 text-base text-foreground transition focus:bg-muted/35 focus:shadow-[0_18px_48px_rgba(17,17,17,0.12)] focus:outline-none focus:ring-0 placeholder:text-muted-foreground/60"
+      />
+    </motion.div>
+  );
+}

--- a/figma/src/components/SimpleMenu.tsx
+++ b/figma/src/components/SimpleMenu.tsx
@@ -1,0 +1,102 @@
+import { ReactNode, useEffect, useRef, useState } from "react";
+import { cn } from "./cn";
+
+export interface SimpleMenuItem {
+  label: string;
+  onSelect?: () => void;
+  disabled?: boolean;
+  hint?: string;
+}
+
+interface SimpleMenuProps {
+  triggerIcon: ReactNode;
+  triggerLabel: string;
+  items: SimpleMenuItem[];
+  triggerClassName?: string;
+  menuClassName?: string;
+}
+
+export function SimpleMenu({
+  triggerIcon,
+  triggerLabel,
+  items,
+  triggerClassName,
+  menuClassName
+}: SimpleMenuProps) {
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    document.addEventListener("keydown", handleKey);
+
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((prev) => !prev)}
+        className={cn(
+          "flex h-11 w-11 items-center justify-center rounded-full bg-foreground/90 text-background transition hover:bg-foreground",
+          triggerClassName
+        )}
+      >
+        {triggerIcon}
+        <span className="sr-only">{triggerLabel}</span>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className={cn(
+            "absolute right-0 top-full z-20 mt-4 w-64 rounded-3xl bg-background/95 p-5 text-sm text-foreground shadow-[0_32px_80px_rgba(17,17,17,0.15)] backdrop-blur",
+            "space-y-2",
+            menuClassName
+          )}
+        >
+          {items.map((item) => (
+            <button
+              key={item.label}
+              type="button"
+              role="menuitem"
+              disabled={item.disabled}
+              onClick={() => {
+                if (item.disabled) return;
+                item.onSelect?.();
+                setOpen(false);
+              }}
+              className={cn(
+                "w-full rounded-2xl px-4 py-3 text-left transition",
+                item.disabled
+                  ? "text-muted-foreground/70"
+                  : "text-foreground/80 hover:bg-foreground/5 hover:text-foreground"
+              )}
+            >
+              <div className="font-medium leading-snug">{item.label}</div>
+              {item.hint && <div className="mt-1 text-xs text-muted-foreground/70">{item.hint}</div>}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/figma/src/components/UploadModal.tsx
+++ b/figma/src/components/UploadModal.tsx
@@ -1,0 +1,325 @@
+import { useEffect, useMemo, useState } from "react";
+import { Modal } from "./Modal";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Textarea } from "./ui/textarea";
+import { CardID, StoreShape } from "../lib/types";
+
+interface UploadModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  store: StoreShape;
+  initialLocation?: CardID | "root";
+  onImportJSON: (file: File, location: CardID | "root") => void;
+  onImportTXT: (file: File, mode: "outline" | "append", location: CardID | "root") => void;
+  onInstallModFile: (file: File) => void;
+  onInstallModCode: (payload: {
+    modId: string;
+    name: string;
+    version: string;
+    author: string;
+    js: string;
+    css: string;
+    enabled: boolean;
+  }) => void;
+}
+
+type TabKey = "json" | "txt" | "mods";
+
+export function UploadModal({
+  open,
+  onOpenChange,
+  store,
+  initialLocation = "root",
+  onImportJSON,
+  onImportTXT,
+  onInstallModFile,
+  onInstallModCode
+}: UploadModalProps) {
+  const [activeTab, setActiveTab] = useState<TabKey>("json");
+  const [jsonLocation, setJsonLocation] = useState<CardID | "root">("root");
+  const [txtLocation, setTxtLocation] = useState<CardID | "root">("root");
+  const [txtMode, setTxtMode] = useState<"outline" | "append">("outline");
+  const [modEnabled, setModEnabled] = useState(true);
+  const [modForm, setModForm] = useState({
+    modId: "",
+    name: "",
+    version: "",
+    author: "",
+    js: "",
+    css: ""
+  });
+
+  const cards = useMemo(
+    () => Object.values(store.cards).sort((a, b) => (a.title || "").localeCompare(b.title || "")),
+    [store.cards]
+  );
+
+  const reset = () => {
+    setActiveTab("json");
+    setJsonLocation("root");
+    setTxtLocation("root");
+    setTxtMode("outline");
+    setModEnabled(true);
+    setModForm({ modId: "", name: "", version: "", author: "", js: "", css: "" });
+  };
+
+  const handleClose = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      reset();
+    }
+    onOpenChange(nextOpen);
+  };
+
+  useEffect(() => {
+    if (open) {
+      setJsonLocation(initialLocation);
+      setTxtLocation(initialLocation);
+    }
+  }, [open, initialLocation]);
+
+  return (
+    <Modal open={open} onOpenChange={handleClose} title="Import Content">
+      <div className="space-y-6">
+        <div className="flex items-center gap-2 rounded-full bg-muted/30 p-1">
+          {(
+            [
+              { value: "json" as const, label: "JSON" },
+              { value: "txt" as const, label: "TXT" },
+              { value: "mods" as const, label: "Extensions" }
+            ] satisfies { value: TabKey; label: string }[]
+          ).map((tab) => (
+            <button
+              key={tab.value}
+              type="button"
+              onClick={() => setActiveTab(tab.value)}
+              className={
+                tab.value === activeTab
+                  ? "flex-1 rounded-full bg-background px-5 py-2 text-sm font-medium text-foreground shadow-sm"
+                  : "flex-1 rounded-full px-5 py-2 text-sm font-medium text-muted-foreground transition hover:text-foreground"
+              }
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+
+        {activeTab === "json" && (
+          <div className="space-y-6">
+            <div className="space-y-3">
+              <label className="text-sm font-medium text-muted-foreground">Select location</label>
+              <select
+                className="w-full rounded-full border border-transparent bg-muted/25 px-5 py-3 text-base text-foreground transition focus:border-foreground/20 focus:bg-muted/35 focus:outline-none"
+                value={jsonLocation}
+                onChange={(event) => setJsonLocation(event.target.value as CardID | "root")}
+              >
+                <option value="root">Import at top level</option>
+                {cards.map((card) => (
+                  <option key={card.id} value={card.id}>
+                    {card.title || "(Untitled)"}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-4 rounded-[28px] bg-muted/20 p-10 text-center">
+              <p className="text-muted-foreground">Upload a JSON package exported from CardSpoke.</p>
+              <Input
+                type="file"
+                accept=".json"
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  if (file) {
+                    onImportJSON(file, jsonLocation);
+                    event.target.value = "";
+                  }
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {activeTab === "txt" && (
+          <div className="space-y-6">
+            <div className="space-y-3">
+              <label className="text-sm font-medium text-muted-foreground">Import mode</label>
+              <div className="flex flex-wrap gap-3 text-sm">
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="txtMode"
+                    checked={txtMode === "outline"}
+                    onChange={() => setTxtMode("outline")}
+                  />
+                  Create cards from outline
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="txtMode"
+                    checked={txtMode === "append"}
+                    onChange={() => setTxtMode("append")}
+                  />
+                  Append to card details
+                </label>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <label className="text-sm font-medium text-muted-foreground">Select location</label>
+              <select
+                className="w-full rounded-full border border-transparent bg-muted/25 px-5 py-3 text-base text-foreground transition focus:border-foreground/20 focus:bg-muted/35 focus:outline-none"
+                value={txtLocation}
+                onChange={(event) => setTxtLocation(event.target.value as CardID | "root")}
+              >
+                <option value="root" disabled={txtMode === "append"}>
+                  Import at top level
+                </option>
+                {cards.map((card) => (
+                  <option key={card.id} value={card.id}>
+                    {card.title || "(Untitled)"}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-4 rounded-[28px] bg-muted/20 p-10 text-center">
+              <p className="text-muted-foreground">Upload a TXT outline exported from CardSpoke or another tool.</p>
+              <Input
+                type="file"
+                accept=".txt"
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  if (file) {
+                    onImportTXT(file, txtMode, txtLocation);
+                    event.target.value = "";
+                  }
+                }}
+              />
+            </div>
+          </div>
+        )}
+
+        {activeTab === "mods" && (
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-muted-foreground">Install from file</label>
+              <Input
+                type="file"
+                accept=".json"
+                onChange={(event) => {
+                  const file = event.target.files?.[0];
+                  if (file) {
+                    onInstallModFile(file);
+                    event.target.value = "";
+                  }
+                }}
+              />
+            </div>
+
+            <div className="space-y-3">
+              <label className="text-sm font-medium text-muted-foreground">Install from code</label>
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-2">
+                  <label className="text-xs uppercase tracking-wide text-muted-foreground" htmlFor="modId">
+                    Extension ID
+                  </label>
+                  <Input
+                    id="modId"
+                    placeholder="unique-id"
+                    value={modForm.modId}
+                    onChange={(event) => setModForm((prev) => ({ ...prev, modId: event.target.value }))}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-xs uppercase tracking-wide text-muted-foreground" htmlFor="modName">
+                    Name
+                  </label>
+                  <Input
+                    id="modName"
+                    placeholder="Display name"
+                    value={modForm.name}
+                    onChange={(event) => setModForm((prev) => ({ ...prev, name: event.target.value }))}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-xs uppercase tracking-wide text-muted-foreground" htmlFor="modVersion">
+                    Version
+                  </label>
+                  <Input
+                    id="modVersion"
+                    placeholder="1.0.0"
+                    value={modForm.version}
+                    onChange={(event) => setModForm((prev) => ({ ...prev, version: event.target.value }))}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <label className="text-xs uppercase tracking-wide text-muted-foreground" htmlFor="modAuthor">
+                    Author
+                  </label>
+                  <Input
+                    id="modAuthor"
+                    placeholder="Your name"
+                    value={modForm.author}
+                    onChange={(event) => setModForm((prev) => ({ ...prev, author: event.target.value }))}
+                  />
+                </div>
+              </div>
+
+              <div className="space-y-2">
+                <label className="text-xs uppercase tracking-wide text-muted-foreground" htmlFor="modJs">
+                  JavaScript
+                </label>
+                <Textarea
+                  id="modJs"
+                  rows={8}
+                  placeholder="window.CIB_MODS.register('my-mod', {...});"
+                  value={modForm.js}
+                  onChange={(event) => setModForm((prev) => ({ ...prev, js: event.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <label className="text-xs uppercase tracking-wide text-muted-foreground" htmlFor="modCss">
+                  CSS (optional)
+                </label>
+                <Textarea
+                  id="modCss"
+                  rows={4}
+                  placeholder=".my-extension { color: inherit; }"
+                  value={modForm.css}
+                  onChange={(event) => setModForm((prev) => ({ ...prev, css: event.target.value }))}
+                />
+              </div>
+
+              <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                <input
+                  type="checkbox"
+                  checked={modEnabled}
+                  onChange={(event) => setModEnabled(event.target.checked)}
+                />
+                Enable extension immediately
+              </label>
+
+              <Button
+                type="button"
+                onClick={() => {
+                  onInstallModCode({
+                    modId: modForm.modId,
+                    name: modForm.name,
+                    version: modForm.version,
+                    author: modForm.author,
+                    js: modForm.js,
+                    css: modForm.css,
+                    enabled: modEnabled
+                  });
+                }}
+              >
+                Install Extension
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/figma/src/components/cn.ts
+++ b/figma/src/components/cn.ts
@@ -1,0 +1,3 @@
+export function cn(...values: Array<string | false | null | undefined>) {
+  return values.filter(Boolean).join(" ");
+}

--- a/figma/src/components/figma/ImageWithFallback.tsx
+++ b/figma/src/components/figma/ImageWithFallback.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react'
+
+const ERROR_IMG_SRC =
+  'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iODgiIGhlaWdodD0iODgiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgc3Ryb2tlPSIjMDAwIiBzdHJva2UtbGluZWpvaW49InJvdW5kIiBvcGFjaXR5PSIuMyIgZmlsbD0ibm9uZSIgc3Ryb2tlLXdpZHRoPSIzLjciPjxyZWN0IHg9IjE2IiB5PSIxNiIgd2lkdGg9IjU2IiBoZWlnaHQ9IjU2IiByeD0iNiIvPjxwYXRoIGQ9Im0xNiA1OCAxNi0xOCAzMiAzMiIvPjxjaXJjbGUgY3g9IjUzIiBjeT0iMzUiIHI9IjciLz48L3N2Zz4KCg=='
+
+export function ImageWithFallback(props: React.ImgHTMLAttributes<HTMLImageElement>) {
+  const [didError, setDidError] = useState(false)
+
+  const handleError = () => {
+    setDidError(true)
+  }
+
+  const { src, alt, style, className, ...rest } = props
+
+  return didError ? (
+    <div
+      className={`inline-block bg-gray-100 text-center align-middle ${className ?? ''}`}
+      style={style}
+    >
+      <div className="flex items-center justify-center w-full h-full">
+        <img src={ERROR_IMG_SRC} alt="Error loading image" {...rest} data-original-url={src} />
+      </div>
+    </div>
+  ) : (
+    <img src={src} alt={alt} className={className} style={style} {...rest} onError={handleError} />
+  )
+}

--- a/figma/src/components/ui/button.tsx
+++ b/figma/src/components/ui/button.tsx
@@ -1,0 +1,48 @@
+import { forwardRef } from "react";
+import { cn } from "../cn";
+
+type ButtonVariant = "primary" | "secondary" | "outline" | "ghost" | "destructive";
+type ButtonSize = "sm" | "md" | "lg" | "icon";
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    "bg-foreground text-background shadow-[0_18px_40px_rgba(17,17,17,0.18)] hover:bg-foreground/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground/20",
+  secondary:
+    "bg-muted/20 text-foreground hover:bg-muted/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground/10",
+  outline:
+    "border border-foreground/20 text-foreground hover:bg-foreground/5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground/10",
+  ghost:
+    "text-foreground hover:bg-foreground/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-foreground/10",
+  destructive:
+    "bg-destructive text-white shadow-[0_18px_40px_rgba(212,24,61,0.25)] hover:bg-destructive/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-destructive/20",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "h-9 px-4 text-sm",
+  md: "h-11 px-6 text-sm",
+  lg: "h-12 px-8 text-base",
+  icon: "h-11 w-11",
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "primary", size = "md", type = "button", ...props }, ref) => (
+    <button
+      ref={ref}
+      type={type}
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-full font-medium transition-all disabled:pointer-events-none disabled:opacity-50",
+        variantClasses[variant],
+        sizeClasses[size],
+        className
+      )}
+      {...props}
+    />
+  )
+);
+
+Button.displayName = "Button";

--- a/figma/src/components/ui/input.tsx
+++ b/figma/src/components/ui/input.tsx
@@ -1,0 +1,18 @@
+import { forwardRef } from "react";
+import { cn } from "../cn";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input({ className, type = "text", ...props }, ref) {
+  return (
+    <input
+      ref={ref}
+      type={type}
+      className={cn(
+        "w-full rounded-full border border-transparent bg-muted/25 px-5 py-3 text-base text-foreground transition focus:border-foreground/20 focus:bg-muted/35 focus:outline-none",
+        className
+      )}
+      {...props}
+    />
+  );
+});

--- a/figma/src/components/ui/textarea.tsx
+++ b/figma/src/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import { forwardRef } from "react";
+import { cn } from "../cn";
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { className, ...props },
+  ref
+) {
+  return (
+    <textarea
+      ref={ref}
+      className={cn(
+        "w-full rounded-3xl border border-transparent bg-muted/20 px-5 py-4 text-base leading-relaxed text-foreground transition focus:border-foreground/20 focus:bg-muted/30 focus:outline-none",
+        className
+      )}
+      {...props}
+    />
+  );
+});

--- a/figma/src/index.css
+++ b/figma/src/index.css
@@ -1,0 +1,1598 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Outfit:wght@300;400;500;600;700;800&display=swap");
+/*! tailwindcss v4.1.3 | MIT License | https://tailwindcss.com */
+@layer properties {
+  @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
+    *, :before, :after, ::backdrop {
+      --tw-translate-x: 0;
+      --tw-translate-y: 0;
+      --tw-translate-z: 0;
+      --tw-space-y-reverse: 0;
+      --tw-border-style: solid;
+      --tw-font-weight: initial;
+      --tw-tracking: initial;
+      --tw-shadow: 0 0 #0000;
+      --tw-shadow-color: initial;
+      --tw-shadow-alpha: 100%;
+      --tw-inset-shadow: 0 0 #0000;
+      --tw-inset-shadow-color: initial;
+      --tw-inset-shadow-alpha: 100%;
+      --tw-ring-color: initial;
+      --tw-ring-shadow: 0 0 #0000;
+      --tw-inset-ring-color: initial;
+      --tw-inset-ring-shadow: 0 0 #0000;
+      --tw-ring-inset: initial;
+      --tw-ring-offset-width: 0px;
+      --tw-ring-offset-color: #fff;
+      --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-outline-style: solid;
+      --tw-blur: initial;
+      --tw-brightness: initial;
+      --tw-contrast: initial;
+      --tw-grayscale: initial;
+      --tw-hue-rotate: initial;
+      --tw-invert: initial;
+      --tw-opacity: initial;
+      --tw-saturate: initial;
+      --tw-sepia: initial;
+      --tw-drop-shadow: initial;
+      --tw-drop-shadow-color: initial;
+      --tw-drop-shadow-alpha: 100%;
+      --tw-drop-shadow-size: initial;
+      --tw-duration: initial;
+    }
+  }
+}
+
+@layer theme {
+  :root, :host {
+    --font-sans: ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    --color-black: #000;
+    --color-white: #fff;
+    --spacing: .25rem;
+    --container-2xl: 42rem;
+    --container-6xl: 72rem;
+    --text-xs: .75rem;
+    --text-xs--line-height: calc(1 / .75);
+    --text-sm: .875rem;
+    --text-sm--line-height: calc(1.25 / .875);
+    --font-weight-normal: 400;
+    --font-weight-medium: 500;
+    --font-weight-bold: 700;
+    --tracking-wide: .025em;
+    --tracking-widest: .1em;
+    --default-transition-duration: .15s;
+    --default-transition-timing-function: cubic-bezier(.4, 0, .2, 1);
+    --default-font-family: var(--font-sans);
+    --default-font-feature-settings: var(--font-sans--font-feature-settings);
+    --default-font-variation-settings: var(--font-sans--font-variation-settings);
+    --default-mono-font-family: var(--font-mono);
+    --default-mono-font-feature-settings: var(--font-mono--font-feature-settings);
+    --default-mono-font-variation-settings: var(--font-mono--font-variation-settings);
+  }
+}
+
+@layer base {
+  *, :after, :before, ::backdrop {
+    box-sizing: border-box;
+    border: 0 solid;
+    margin: 0;
+    padding: 0;
+  }
+
+  ::file-selector-button {
+    box-sizing: border-box;
+    border: 0 solid;
+    margin: 0;
+    padding: 0;
+  }
+
+  html, :host {
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    line-height: 1.5;
+    font-family: var(--default-font-family, ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji");
+    font-feature-settings: var(--default-font-feature-settings, normal);
+    font-variation-settings: var(--default-font-variation-settings, normal);
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  body {
+    line-height: inherit;
+  }
+
+  hr {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  abbr:where([title]) {
+    -webkit-text-decoration: underline dotted;
+    text-decoration: underline dotted;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  a {
+    color: inherit;
+    -webkit-text-decoration: inherit;
+    -webkit-text-decoration: inherit;
+    text-decoration: inherit;
+  }
+
+  b, strong {
+    font-weight: bolder;
+  }
+
+  code, kbd, samp, pre {
+    font-family: var(--default-mono-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace);
+    font-feature-settings: var(--default-mono-font-feature-settings, normal);
+    font-variation-settings: var(--default-mono-font-variation-settings, normal);
+    font-size: 1em;
+  }
+
+  small {
+    font-size: 80%;
+  }
+
+  sub, sup {
+    vertical-align: baseline;
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+  }
+
+  sub {
+    bottom: -.25em;
+  }
+
+  sup {
+    top: -.5em;
+  }
+
+  table {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  :-moz-focusring {
+    outline: auto;
+  }
+
+  progress {
+    vertical-align: baseline;
+  }
+
+  summary {
+    display: list-item;
+  }
+
+  ol, ul, menu {
+    list-style: none;
+  }
+
+  img, svg, video, canvas, audio, iframe, embed, object {
+    vertical-align: middle;
+    display: block;
+  }
+
+  img, video {
+    max-width: 100%;
+    height: auto;
+  }
+
+  button, input, select, optgroup, textarea {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    opacity: 1;
+    background-color: #0000;
+    border-radius: 0;
+  }
+
+  ::file-selector-button {
+    font: inherit;
+    font-feature-settings: inherit;
+    font-variation-settings: inherit;
+    letter-spacing: inherit;
+    color: inherit;
+    opacity: 1;
+    background-color: #0000;
+    border-radius: 0;
+  }
+
+  :where(select:is([multiple], [size])) optgroup {
+    font-weight: bolder;
+  }
+
+  :where(select:is([multiple], [size])) optgroup option {
+    padding-inline-start: 20px;
+  }
+
+  ::file-selector-button {
+    margin-inline-end: 4px;
+  }
+
+  ::placeholder {
+    opacity: 1;
+    color: currentColor;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    ::placeholder {
+      color: color-mix(in oklab, currentColor 50%, transparent);
+    }
+  }
+
+  textarea {
+    resize: vertical;
+  }
+
+  ::-webkit-search-decoration {
+    -webkit-appearance: none;
+  }
+
+  ::-webkit-date-and-time-value {
+    min-height: 1lh;
+    text-align: inherit;
+  }
+
+  ::-webkit-datetime-edit {
+    display: inline-flex;
+  }
+
+  ::-webkit-datetime-edit-fields-wrapper {
+    padding: 0;
+  }
+
+  ::-webkit-datetime-edit {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-year-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-month-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-day-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-hour-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-minute-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-second-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-millisecond-field {
+    padding-block: 0;
+  }
+
+  ::-webkit-datetime-edit-meridiem-field {
+    padding-block: 0;
+  }
+
+  :-moz-ui-invalid {
+    box-shadow: none;
+  }
+
+  button, input:where([type="button"], [type="reset"], [type="submit"]) {
+    appearance: button;
+  }
+
+  ::file-selector-button {
+    appearance: button;
+  }
+
+  ::-webkit-inner-spin-button {
+    height: auto;
+  }
+
+  ::-webkit-outer-spin-button {
+    height: auto;
+  }
+
+  [hidden]:where(:not([hidden="until-found"])) {
+    display: none !important;
+  }
+
+  * {
+    border-color: var(--border);
+    outline-color: var(--ring);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    * {
+      outline-color: color-mix(in oklab, var(--ring) 50%, transparent);
+    }
+  }
+
+  body {
+    background-color: var(--background);
+    color: var(--foreground);
+  }
+
+  * {
+    border-color: var(--border);
+    outline-color: var(--ring);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    * {
+      outline-color: color-mix(in oklab, var(--ring) 50%, transparent);
+    }
+  }
+
+  body {
+    background-color: var(--background);
+    color: var(--foreground);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-family: Outfit, Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+  }
+
+  :where(:not(:has([class*=" text-"]), :not(:has([class^="text-"])))) h1 {
+    letter-spacing: -.03em;
+    font-family: Outfit, Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 96px;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  :where(:not(:has([class*=" text-"]), :not(:has([class^="text-"])))) h2 {
+    letter-spacing: -.04em;
+    font-family: Outfit, Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 72px;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  :where(:not(:has([class*=" text-"]), :not(:has([class^="text-"])))) h3 {
+    letter-spacing: -.025em;
+    font-family: Outfit, Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 32px;
+    font-weight: 700;
+    line-height: 1.15;
+  }
+
+  :where(:not(:has([class*=" text-"]), :not(:has([class^="text-"])))) h4 {
+    letter-spacing: -.02em;
+    font-family: Outfit, Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 1.3;
+  }
+
+  :where(:not(:has([class*=" text-"]), :not(:has([class^="text-"])))) p {
+    letter-spacing: -.01em;
+    font-family: Outfit, Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 1.7;
+  }
+
+  :where(:not(:has([class*=" text-"]), :not(:has([class^="text-"])))) label {
+    letter-spacing: -.01em;
+    font-family: Outfit, Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.4;
+  }
+
+  :where(:not(:has([class*=" text-"]), :not(:has([class^="text-"])))) button {
+    letter-spacing: -.01em;
+    font-family: Outfit, Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 15px;
+    font-weight: 500;
+    line-height: 1.5;
+  }
+
+  :where(:not(:has([class*=" text-"]), :not(:has([class^="text-"])))) input {
+    letter-spacing: -.01em;
+    font-family: Outfit, Inter, -apple-system, BlinkMacSystemFont, sans-serif;
+    font-size: 16px;
+    font-weight: 400;
+    line-height: 1.5;
+  }
+}
+
+@layer utilities {
+  .pointer-events-none {
+    pointer-events: none;
+  }
+
+  .absolute {
+    position: absolute;
+  }
+
+  .relative {
+    position: relative;
+  }
+
+  .top-1\/2 {
+    top: 50%;
+  }
+
+  .left-0 {
+    left: calc(var(--spacing) * 0);
+  }
+
+  .left-2 {
+    left: calc(var(--spacing) * 2);
+  }
+
+  .z-50 {
+    z-index: 50;
+  }
+
+  .-mx-1 {
+    margin-inline: calc(var(--spacing) * -1);
+  }
+
+  .mx-auto {
+    margin-inline: auto;
+  }
+
+  .my-1 {
+    margin-block: calc(var(--spacing) * 1);
+  }
+
+  .mt-2 {
+    margin-top: calc(var(--spacing) * 2);
+  }
+
+  .mt-24 {
+    margin-top: calc(var(--spacing) * 24);
+  }
+
+  .mb-8 {
+    margin-bottom: calc(var(--spacing) * 8);
+  }
+
+  .mb-16 {
+    margin-bottom: calc(var(--spacing) * 16);
+  }
+
+  .ml-auto {
+    margin-left: auto;
+  }
+
+  .flex {
+    display: flex;
+  }
+
+  .inline-flex {
+    display: inline-flex;
+  }
+
+  .size-2 {
+    width: calc(var(--spacing) * 2);
+    height: calc(var(--spacing) * 2);
+  }
+
+  .size-3\.5 {
+    width: calc(var(--spacing) * 3.5);
+    height: calc(var(--spacing) * 3.5);
+  }
+
+  .size-4 {
+    width: calc(var(--spacing) * 4);
+    height: calc(var(--spacing) * 4);
+  }
+
+  .size-9 {
+    width: calc(var(--spacing) * 9);
+    height: calc(var(--spacing) * 9);
+  }
+
+  .h-5 {
+    height: calc(var(--spacing) * 5);
+  }
+
+  .h-8 {
+    height: calc(var(--spacing) * 8);
+  }
+
+  .h-9 {
+    height: calc(var(--spacing) * 9);
+  }
+
+  .h-10 {
+    height: calc(var(--spacing) * 10);
+  }
+
+  .h-11 {
+    height: calc(var(--spacing) * 11);
+  }
+
+  .h-px {
+    height: 1px;
+  }
+
+  .max-h-\(--radix-dropdown-menu-content-available-height\) {
+    max-height: var(--radix-dropdown-menu-content-available-height);
+  }
+
+  .min-h-screen {
+    min-height: 100vh;
+  }
+
+  .w-5 {
+    width: calc(var(--spacing) * 5);
+  }
+
+  .w-11 {
+    width: calc(var(--spacing) * 11);
+  }
+
+  .w-56 {
+    width: calc(var(--spacing) * 56);
+  }
+
+  .w-full {
+    width: 100%;
+  }
+
+  .max-w-2xl {
+    max-width: var(--container-2xl);
+  }
+
+  .max-w-6xl {
+    max-width: var(--container-6xl);
+  }
+
+  .min-w-\[8rem\] {
+    min-width: 8rem;
+  }
+
+  .flex-1 {
+    flex: 1;
+  }
+
+  .flex-shrink-0, .shrink-0 {
+    flex-shrink: 0;
+  }
+
+  .origin-\(--radix-dropdown-menu-content-transform-origin\) {
+    transform-origin: var(--radix-dropdown-menu-content-transform-origin);
+  }
+
+  .-translate-y-1\/2 {
+    --tw-translate-y: calc(calc(1 / 2 * 100%) * -1);
+    translate: var(--tw-translate-x) var(--tw-translate-y);
+  }
+
+  .cursor-default {
+    cursor: default;
+  }
+
+  .cursor-pointer {
+    cursor: pointer;
+  }
+
+  .items-center {
+    align-items: center;
+  }
+
+  .items-start {
+    align-items: flex-start;
+  }
+
+  .justify-between {
+    justify-content: space-between;
+  }
+
+  .justify-center {
+    justify-content: center;
+  }
+
+  .gap-1\.5 {
+    gap: calc(var(--spacing) * 1.5);
+  }
+
+  .gap-2 {
+    gap: calc(var(--spacing) * 2);
+  }
+
+  .gap-16 {
+    gap: calc(var(--spacing) * 16);
+  }
+
+  :where(.space-y-4 > :not(:last-child)) {
+    --tw-space-y-reverse: 0;
+    margin-block-start: calc(calc(var(--spacing) * 4) * var(--tw-space-y-reverse));
+    margin-block-end: calc(calc(var(--spacing) * 4) * calc(1 - var(--tw-space-y-reverse)));
+  }
+
+  :where(.space-y-12 > :not(:last-child)) {
+    --tw-space-y-reverse: 0;
+    margin-block-start: calc(calc(var(--spacing) * 12) * var(--tw-space-y-reverse));
+    margin-block-end: calc(calc(var(--spacing) * 12) * calc(1 - var(--tw-space-y-reverse)));
+  }
+
+  .overflow-hidden {
+    overflow: hidden;
+  }
+
+  .overflow-x-hidden {
+    overflow-x: hidden;
+  }
+
+  .overflow-y-auto {
+    overflow-y: auto;
+  }
+
+  .rounded-full {
+    border-radius: 3.40282e38px;
+  }
+
+  .rounded-lg {
+    border-radius: var(--radius);
+  }
+
+  .rounded-md {
+    border-radius: calc(var(--radius)  - 2px);
+  }
+
+  .rounded-sm {
+    border-radius: calc(var(--radius)  - 4px);
+  }
+
+  .border {
+    border-style: var(--tw-border-style);
+    border-width: 1px;
+  }
+
+  .border-t {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
+  }
+
+  .border-b {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
+  }
+
+  .border-border {
+    border-color: var(--border);
+  }
+
+  .border-foreground\/20 {
+    border-color: var(--foreground);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .border-foreground\/20 {
+      border-color: color-mix(in oklab, var(--foreground) 20%, transparent);
+    }
+  }
+
+  .bg-background {
+    background-color: var(--background);
+  }
+
+  .bg-border {
+    background-color: var(--border);
+  }
+
+  .bg-destructive {
+    background-color: var(--destructive);
+  }
+
+  .bg-popover {
+    background-color: var(--popover);
+  }
+
+  .bg-primary {
+    background-color: var(--primary);
+  }
+
+  .bg-secondary {
+    background-color: var(--secondary);
+  }
+
+  .bg-transparent {
+    background-color: #0000;
+  }
+
+  .fill-current {
+    fill: currentColor;
+  }
+
+  .p-1 {
+    padding: calc(var(--spacing) * 1);
+  }
+
+  .p-8 {
+    padding: calc(var(--spacing) * 8);
+  }
+
+  .px-2 {
+    padding-inline: calc(var(--spacing) * 2);
+  }
+
+  .px-3 {
+    padding-inline: calc(var(--spacing) * 3);
+  }
+
+  .px-4 {
+    padding-inline: calc(var(--spacing) * 4);
+  }
+
+  .px-6 {
+    padding-inline: calc(var(--spacing) * 6);
+  }
+
+  .px-16 {
+    padding-inline: calc(var(--spacing) * 16);
+  }
+
+  .py-1\.5 {
+    padding-block: calc(var(--spacing) * 1.5);
+  }
+
+  .py-2 {
+    padding-block: calc(var(--spacing) * 2);
+  }
+
+  .py-3 {
+    padding-block: calc(var(--spacing) * 3);
+  }
+
+  .py-4 {
+    padding-block: calc(var(--spacing) * 4);
+  }
+
+  .py-12 {
+    padding-block: calc(var(--spacing) * 12);
+  }
+
+  .py-20 {
+    padding-block: calc(var(--spacing) * 20);
+  }
+
+  .pt-2 {
+    padding-top: calc(var(--spacing) * 2);
+  }
+
+  .pt-12 {
+    padding-top: calc(var(--spacing) * 12);
+  }
+
+  .pr-2 {
+    padding-right: calc(var(--spacing) * 2);
+  }
+
+  .pr-4 {
+    padding-right: calc(var(--spacing) * 4);
+  }
+
+  .pb-12 {
+    padding-bottom: calc(var(--spacing) * 12);
+  }
+
+  .pb-32 {
+    padding-bottom: calc(var(--spacing) * 32);
+  }
+
+  .pl-8 {
+    padding-left: calc(var(--spacing) * 8);
+  }
+
+  .pl-10 {
+    padding-left: calc(var(--spacing) * 10);
+  }
+
+  .font-\[Inter\] {
+    font-family: Inter;
+  }
+
+  .text-sm {
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+  }
+
+  .text-xs {
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+  }
+
+  .text-\[64px\] {
+    font-size: 64px;
+  }
+
+  .font-bold {
+    --tw-font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-bold);
+  }
+
+  .font-medium {
+    --tw-font-weight: var(--font-weight-medium);
+    font-weight: var(--font-weight-medium);
+  }
+
+  .font-normal {
+    --tw-font-weight: var(--font-weight-normal);
+    font-weight: var(--font-weight-normal);
+  }
+
+  .tracking-wide {
+    --tw-tracking: var(--tracking-wide);
+    letter-spacing: var(--tracking-wide);
+  }
+
+  .tracking-widest {
+    --tw-tracking: var(--tracking-widest);
+    letter-spacing: var(--tracking-widest);
+  }
+
+  .whitespace-nowrap {
+    white-space: nowrap;
+  }
+
+  .text-black {
+    color: var(--color-black);
+  }
+
+  .text-foreground {
+    color: var(--foreground);
+  }
+
+  .text-muted-foreground {
+    color: var(--muted-foreground);
+  }
+
+  .text-popover-foreground {
+    color: var(--popover-foreground);
+  }
+
+  .text-primary {
+    color: var(--primary);
+  }
+
+  .text-primary-foreground {
+    color: var(--primary-foreground);
+  }
+
+  .text-secondary-foreground {
+    color: var(--secondary-foreground);
+  }
+
+  .text-white {
+    color: var(--color-white);
+  }
+
+  .italic {
+    font-style: italic;
+  }
+
+  .underline-offset-4 {
+    text-underline-offset: 4px;
+  }
+
+  .opacity-30 {
+    opacity: .3;
+  }
+
+  .shadow-lg {
+    --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, #0000001a), 0 4px 6px -4px var(--tw-shadow-color, #0000001a);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
+  .shadow-md {
+    --tw-shadow: 0 4px 6px -1px var(--tw-shadow-color, #0000001a), 0 2px 4px -2px var(--tw-shadow-color, #0000001a);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
+  .outline-hidden {
+    --tw-outline-style: none;
+    outline-style: none;
+  }
+
+  @media (forced-colors: active) {
+    .outline-hidden {
+      outline-offset: 2px;
+      outline: 2px solid #0000;
+    }
+  }
+
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
+  }
+
+  .filter {
+    filter: var(--tw-blur, ) var(--tw-brightness, ) var(--tw-contrast, ) var(--tw-grayscale, ) var(--tw-hue-rotate, ) var(--tw-invert, ) var(--tw-saturate, ) var(--tw-sepia, ) var(--tw-drop-shadow, );
+  }
+
+  .transition {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+
+  .transition-all {
+    transition-property: all;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+
+  .transition-colors {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+
+  .transition-opacity {
+    transition-property: opacity;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+
+  .transition-shadow {
+    transition-property: box-shadow;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+
+  .duration-500 {
+    --tw-duration: .5s;
+    transition-duration: .5s;
+  }
+
+  .outline-none {
+    --tw-outline-style: none;
+    outline-style: none;
+  }
+
+  .select-none {
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  @media (hover: hover) {
+    .group-hover\:opacity-50:is(:where(.group):hover *) {
+      opacity: .5;
+    }
+  }
+
+  @media (hover: hover) {
+    .group-hover\:opacity-60:is(:where(.group):hover *) {
+      opacity: .6;
+    }
+  }
+
+  .placeholder\:text-muted-foreground\/50::placeholder {
+    color: var(--muted-foreground);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .placeholder\:text-muted-foreground\/50::placeholder {
+      color: color-mix(in oklab, var(--muted-foreground) 50%, transparent);
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:bg-accent:hover {
+      background-color: var(--accent);
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:bg-destructive\/90:hover {
+      background-color: var(--destructive);
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .hover\:bg-destructive\/90:hover {
+        background-color: color-mix(in oklab, var(--destructive) 90%, transparent);
+      }
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:bg-primary\/90:hover {
+      background-color: var(--primary);
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .hover\:bg-primary\/90:hover {
+        background-color: color-mix(in oklab, var(--primary) 90%, transparent);
+      }
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:bg-secondary\/80:hover {
+      background-color: var(--secondary);
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .hover\:bg-secondary\/80:hover {
+        background-color: color-mix(in oklab, var(--secondary) 80%, transparent);
+      }
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:text-accent-foreground:hover {
+      color: var(--accent-foreground);
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:underline:hover {
+      text-decoration-line: underline;
+    }
+  }
+
+  @media (hover: hover) {
+    .hover\:shadow-lg:hover {
+      --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, #0000001a), 0 4px 6px -4px var(--tw-shadow-color, #0000001a);
+      box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    }
+  }
+
+  .focus\:border-foreground:focus {
+    border-color: var(--foreground);
+  }
+
+  .focus\:bg-accent:focus {
+    background-color: var(--accent);
+  }
+
+  .focus\:text-accent-foreground:focus {
+    color: var(--accent-foreground);
+  }
+
+  .focus-visible\:border-ring:focus-visible {
+    border-color: var(--ring);
+  }
+
+  .focus-visible\:ring-\[3px\]:focus-visible {
+    --tw-ring-shadow: var(--tw-ring-inset, ) 0 0 0 calc(3px + var(--tw-ring-offset-width)) var(--tw-ring-color, currentcolor);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
+  .focus-visible\:ring-destructive\/20:focus-visible {
+    --tw-ring-color: var(--destructive);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .focus-visible\:ring-destructive\/20:focus-visible {
+      --tw-ring-color: color-mix(in oklab, var(--destructive) 20%, transparent);
+    }
+  }
+
+  .focus-visible\:ring-ring\/50:focus-visible {
+    --tw-ring-color: var(--ring);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .focus-visible\:ring-ring\/50:focus-visible {
+      --tw-ring-color: color-mix(in oklab, var(--ring) 50%, transparent);
+    }
+  }
+
+  .disabled\:pointer-events-none:disabled {
+    pointer-events: none;
+  }
+
+  .disabled\:opacity-50:disabled {
+    opacity: .5;
+  }
+
+  .has-\[\>svg\]\:px-2\.5:has( > svg) {
+    padding-inline: calc(var(--spacing) * 2.5);
+  }
+
+  .has-\[\>svg\]\:px-3:has( > svg) {
+    padding-inline: calc(var(--spacing) * 3);
+  }
+
+  .has-\[\>svg\]\:px-4:has( > svg) {
+    padding-inline: calc(var(--spacing) * 4);
+  }
+
+  .aria-invalid\:border-destructive[aria-invalid="true"] {
+    border-color: var(--destructive);
+  }
+
+  .aria-invalid\:ring-destructive\/20[aria-invalid="true"] {
+    --tw-ring-color: var(--destructive);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .aria-invalid\:ring-destructive\/20[aria-invalid="true"] {
+      --tw-ring-color: color-mix(in oklab, var(--destructive) 20%, transparent);
+    }
+  }
+
+  .data-\[disabled\]\:pointer-events-none[data-disabled] {
+    pointer-events: none;
+  }
+
+  .data-\[disabled\]\:opacity-50[data-disabled] {
+    opacity: .5;
+  }
+
+  .data-\[inset\]\:pl-8[data-inset] {
+    padding-left: calc(var(--spacing) * 8);
+  }
+
+  .data-\[side\=bottom\]\:slide-in-from-top-2[data-side="bottom"] {
+    --tw-enter-translate-y: calc(2 * var(--spacing) * -1);
+  }
+
+  .data-\[side\=left\]\:slide-in-from-right-2[data-side="left"] {
+    --tw-enter-translate-x: calc(2 * var(--spacing));
+  }
+
+  .data-\[side\=right\]\:slide-in-from-left-2[data-side="right"] {
+    --tw-enter-translate-x: calc(2 * var(--spacing) * -1);
+  }
+
+  .data-\[side\=top\]\:slide-in-from-bottom-2[data-side="top"] {
+    --tw-enter-translate-y: calc(2 * var(--spacing));
+  }
+
+  .data-\[state\=closed\]\:animate-out[data-state="closed"] {
+    animation: exit var(--tw-duration, .15s) var(--tw-ease, ease);
+  }
+
+  .data-\[state\=closed\]\:fade-out-0[data-state="closed"] {
+    --tw-exit-opacity: 0;
+  }
+
+  .data-\[state\=closed\]\:zoom-out-95[data-state="closed"] {
+    --tw-exit-scale: .95;
+  }
+
+  .data-\[state\=open\]\:animate-in[data-state="open"] {
+    animation: enter var(--tw-duration, .15s) var(--tw-ease, ease);
+  }
+
+  .data-\[state\=open\]\:bg-accent[data-state="open"] {
+    background-color: var(--accent);
+  }
+
+  .data-\[state\=open\]\:text-accent-foreground[data-state="open"] {
+    color: var(--accent-foreground);
+  }
+
+  .data-\[state\=open\]\:fade-in-0[data-state="open"] {
+    --tw-enter-opacity: 0;
+  }
+
+  .data-\[state\=open\]\:zoom-in-95[data-state="open"] {
+    --tw-enter-scale: .95;
+  }
+
+  .data-\[variant\=destructive\]\:text-destructive[data-variant="destructive"] {
+    color: var(--destructive);
+  }
+
+  .data-\[variant\=destructive\]\:focus\:bg-destructive\/10[data-variant="destructive"]:focus {
+    background-color: var(--destructive);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .data-\[variant\=destructive\]\:focus\:bg-destructive\/10[data-variant="destructive"]:focus {
+      background-color: color-mix(in oklab, var(--destructive) 10%, transparent);
+    }
+  }
+
+  .data-\[variant\=destructive\]\:focus\:text-destructive[data-variant="destructive"]:focus {
+    color: var(--destructive);
+  }
+
+  .dark\:border-input:is(.dark *) {
+    border-color: var(--input);
+  }
+
+  .dark\:bg-destructive\/60:is(.dark *) {
+    background-color: var(--destructive);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .dark\:bg-destructive\/60:is(.dark *) {
+      background-color: color-mix(in oklab, var(--destructive) 60%, transparent);
+    }
+  }
+
+  .dark\:bg-input\/30:is(.dark *) {
+    background-color: var(--input);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .dark\:bg-input\/30:is(.dark *) {
+      background-color: color-mix(in oklab, var(--input) 30%, transparent);
+    }
+  }
+
+  @media (hover: hover) {
+    .dark\:hover\:bg-accent\/50:is(.dark *):hover {
+      background-color: var(--accent);
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .dark\:hover\:bg-accent\/50:is(.dark *):hover {
+        background-color: color-mix(in oklab, var(--accent) 50%, transparent);
+      }
+    }
+  }
+
+  @media (hover: hover) {
+    .dark\:hover\:bg-input\/50:is(.dark *):hover {
+      background-color: var(--input);
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .dark\:hover\:bg-input\/50:is(.dark *):hover {
+        background-color: color-mix(in oklab, var(--input) 50%, transparent);
+      }
+    }
+  }
+
+  .dark\:focus-visible\:ring-destructive\/40:is(.dark *):focus-visible {
+    --tw-ring-color: var(--destructive);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .dark\:focus-visible\:ring-destructive\/40:is(.dark *):focus-visible {
+      --tw-ring-color: color-mix(in oklab, var(--destructive) 40%, transparent);
+    }
+  }
+
+  .dark\:aria-invalid\:ring-destructive\/40:is(.dark *)[aria-invalid="true"] {
+    --tw-ring-color: var(--destructive);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .dark\:aria-invalid\:ring-destructive\/40:is(.dark *)[aria-invalid="true"] {
+      --tw-ring-color: color-mix(in oklab, var(--destructive) 40%, transparent);
+    }
+  }
+
+  .dark\:data-\[variant\=destructive\]\:focus\:bg-destructive\/20:is(.dark *)[data-variant="destructive"]:focus {
+    background-color: var(--destructive);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .dark\:data-\[variant\=destructive\]\:focus\:bg-destructive\/20:is(.dark *)[data-variant="destructive"]:focus {
+      background-color: color-mix(in oklab, var(--destructive) 20%, transparent);
+    }
+  }
+
+  .\[\&_svg\]\:pointer-events-none svg {
+    pointer-events: none;
+  }
+
+  .\[\&_svg\]\:shrink-0 svg {
+    flex-shrink: 0;
+  }
+
+  .\[\&_svg\:not\(\[class\*\=\'size-\'\]\)\]\:size-4 svg:not([class*="size-"]) {
+    width: calc(var(--spacing) * 4);
+    height: calc(var(--spacing) * 4);
+  }
+
+  .\[\&_svg\:not\(\[class\*\=\'text-\'\]\)\]\:text-muted-foreground svg:not([class*="text-"]) {
+    color: var(--muted-foreground);
+  }
+
+  :is(.data-\[variant\=destructive\]\:\*\:\[svg\]\:\!text-destructive[data-variant="destructive"] > *):is(svg) {
+    color: var(--destructive) !important;
+  }
+}
+
+
+:root {
+  --font-size: 18px;
+  --background: #fff;
+  --foreground: #111;
+  --card: #fff;
+  --card-foreground: #111;
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(.145 0 0);
+  --primary: #111;
+  --primary-foreground: #fff;
+  --secondary: oklch(.98 .0058 264.53);
+  --secondary-foreground: #111;
+  --muted: #fafafa;
+  --muted-foreground: #666;
+  --accent: #f5f5f5;
+  --accent-foreground: #111;
+  --destructive: #d4183d;
+  --destructive-foreground: #fff;
+  --border: #00000014;
+  --input: transparent;
+  --input-background: #fff;
+  --switch-background: #cbced4;
+  --font-weight-light: 300;
+  --font-weight-medium: 500;
+  --font-weight-normal: 400;
+  --font-weight-bold: 700;
+  --ring: oklch(.708 0 0);
+  --chart-1: oklch(.646 .222 41.116);
+  --chart-2: oklch(.6 .118 184.704);
+  --chart-3: oklch(.398 .07 227.392);
+  --chart-4: oklch(.828 .189 84.429);
+  --chart-5: oklch(.769 .188 70.08);
+  --radius: .25rem;
+  --sidebar: oklch(.985 0 0);
+  --sidebar-foreground: oklch(.145 0 0);
+  --sidebar-primary: #111;
+  --sidebar-primary-foreground: oklch(.985 0 0);
+  --sidebar-accent: oklch(.97 0 0);
+  --sidebar-accent-foreground: oklch(.205 0 0);
+  --sidebar-border: oklch(.922 0 0);
+  --sidebar-ring: oklch(.708 0 0);
+}
+
+.dark {
+  --background: oklch(.145 0 0);
+  --foreground: oklch(.985 0 0);
+  --card: oklch(.145 0 0);
+  --card-foreground: oklch(.985 0 0);
+  --popover: oklch(.145 0 0);
+  --popover-foreground: oklch(.985 0 0);
+  --primary: oklch(.985 0 0);
+  --primary-foreground: oklch(.205 0 0);
+  --secondary: oklch(.269 0 0);
+  --secondary-foreground: oklch(.985 0 0);
+  --muted: oklch(.269 0 0);
+  --muted-foreground: oklch(.708 0 0);
+  --accent: oklch(.269 0 0);
+  --accent-foreground: oklch(.985 0 0);
+  --destructive: oklch(.396 .141 25.723);
+  --destructive-foreground: oklch(.637 .237 25.331);
+  --border: oklch(.269 0 0);
+  --input: oklch(.269 0 0);
+  --ring: oklch(.439 0 0);
+  --font-weight-medium: 500;
+  --font-weight-normal: 400;
+  --chart-1: oklch(.488 .243 264.376);
+  --chart-2: oklch(.696 .17 162.48);
+  --chart-3: oklch(.769 .188 70.08);
+  --chart-4: oklch(.627 .265 303.9);
+  --chart-5: oklch(.645 .246 16.439);
+  --sidebar: oklch(.205 0 0);
+  --sidebar-foreground: oklch(.985 0 0);
+  --sidebar-primary: oklch(.488 .243 264.376);
+  --sidebar-primary-foreground: oklch(.985 0 0);
+  --sidebar-accent: oklch(.269 0 0);
+  --sidebar-accent-foreground: oklch(.985 0 0);
+  --sidebar-border: oklch(.269 0 0);
+  --sidebar-ring: oklch(.439 0 0);
+}
+
+html {
+  font-size: var(--font-size);
+}
+
+@property --tw-translate-x {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --tw-translate-y {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --tw-translate-z {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --tw-space-y-reverse {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --tw-border-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+
+@property --tw-font-weight {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-tracking {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+
+@property --tw-shadow-color {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --tw-inset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+
+@property --tw-inset-shadow-color {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-inset-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --tw-ring-color {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+
+@property --tw-inset-ring-color {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-inset-ring-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+
+@property --tw-ring-inset {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-ring-offset-width {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0;
+}
+
+@property --tw-ring-offset-color {
+  syntax: "*";
+  inherits: false;
+  initial-value: #fff;
+}
+
+@property --tw-ring-offset-shadow {
+  syntax: "*";
+  inherits: false;
+  initial-value: 0 0 #0000;
+}
+
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
+
+@property --tw-blur {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-brightness {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-contrast {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-grayscale {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-hue-rotate {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-invert {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-opacity {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-saturate {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-sepia {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-drop-shadow {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-drop-shadow-color {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-drop-shadow-alpha {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 100%;
+}
+
+@property --tw-drop-shadow-size {
+  syntax: "*";
+  inherits: false
+}
+
+@property --tw-duration {
+  syntax: "*";
+  inherits: false
+}
+
+@keyframes enter {
+  from {
+    opacity: var(--tw-enter-opacity, 1);
+    transform: translate3d(var(--tw-enter-translate-x, 0), var(--tw-enter-translate-y, 0), 0) scale3d(var(--tw-enter-scale, 1), var(--tw-enter-scale, 1), var(--tw-enter-scale, 1)) rotate(var(--tw-enter-rotate, 0));
+  }
+}
+
+@keyframes exit {
+  to {
+    opacity: var(--tw-exit-opacity, 1);
+    transform: translate3d(var(--tw-exit-translate-x, 0), var(--tw-exit-translate-y, 0), 0) scale3d(var(--tw-exit-scale, 1), var(--tw-exit-scale, 1), var(--tw-exit-scale, 1)) rotate(var(--tw-exit-rotate, 0));
+  }
+}

--- a/figma/src/lib/download.ts
+++ b/figma/src/lib/download.ts
@@ -1,0 +1,20 @@
+export function downloadFile(filename: string, blob: Blob) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+export function downloadJSON(filename: string, data: unknown) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+  downloadFile(filename, blob);
+}
+
+export function downloadTXT(filename: string, text: string) {
+  const blob = new Blob([text], { type: "text/plain" });
+  downloadFile(filename, blob);
+}

--- a/figma/src/lib/format.ts
+++ b/figma/src/lib/format.ts
@@ -1,0 +1,12 @@
+export function formatDate(timestamp?: number) {
+  if (!timestamp) return '';
+  const date = new Date(timestamp);
+  return `${date.toLocaleDateString()} ${date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+}
+
+export function bodyPreview(body: string, length = 180) {
+  if (!body) return 'No details yet.';
+  const normalized = body.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= length) return normalized;
+  return normalized.slice(0, length - 1) + '…';
+}

--- a/figma/src/lib/modRuntime.ts
+++ b/figma/src/lib/modRuntime.ts
@@ -1,0 +1,195 @@
+import { APP_VERSION, SCHEMA_VERSION, cloneCard } from "./store";
+import { Card, ModData, ModMeta, NavState, PageName, StoreShape } from "./types";
+
+export type ModHookName = "onAppInit" | "onCardRender" | "onCardSave" | "onCardDelete";
+
+export interface ModRuntimeDeps {
+  getStore: () => StoreShape;
+  getNavState: () => NavState;
+  navigate: (page: PageName, options?: Partial<NavState>) => void;
+  showToast: (message: string, type?: "success" | "error") => void;
+  markDirty?: () => void;
+}
+
+interface ModRegistryEntry {
+  id: string;
+  hooks: Partial<Record<ModHookName, (...args: any[]) => void>>;
+  meta: ModMeta;
+  __loaded?: boolean;
+  __error?: unknown;
+}
+
+interface ModRuntime {
+  registry: Record<string, ModRegistryEntry>;
+  _registry: Record<string, ModRegistryEntry>;
+  register: (modId: string, definition?: Partial<Record<ModHookName, (...args: any[]) => void>> & { meta?: ModMeta }) => ModRegistryEntry;
+  enable: (modId: string, modData: ModData) => boolean;
+  disable: (modId: string) => boolean;
+  syncFromStore: (store: StoreShape) => void;
+  runHook: (name: ModHookName, ...args: any[]) => void;
+}
+
+export function createModRuntime(deps: ModRuntimeDeps): ModRuntime {
+  const registry: Record<string, ModRegistryEntry> = {};
+  const styleTags: Record<string, HTMLStyleElement> = {};
+  const initializedMods = new Set<string>();
+
+  const ensureStyle = (modId: string, css: string | undefined) => {
+    if (!css || styleTags[modId]) return;
+    const tag = document.createElement("style");
+    tag.setAttribute("data-mod-style", modId);
+    tag.textContent = css;
+    document.head.appendChild(tag);
+    styleTags[modId] = tag;
+  };
+
+  const removeStyle = (modId: string) => {
+    const tag = styleTags[modId];
+    if (tag && tag.parentNode) tag.parentNode.removeChild(tag);
+    delete styleTags[modId];
+  };
+
+  const createStoreAPI = (modId: string) => {
+    return {
+      getAppInfo() {
+        return { appVersion: APP_VERSION, schemaVersion: SCHEMA_VERSION };
+      },
+      getCard(id: string) {
+        const store = deps.getStore();
+        return cloneCard(store.cards[id]);
+      },
+      listCards() {
+        const store = deps.getStore();
+        return Object.values(store.cards).map((card) => cloneCard(card));
+      },
+      listRootIds() {
+        const store = deps.getStore();
+        return [...store.rootOrder];
+      },
+      getNavState() {
+        return { ...deps.getNavState() };
+      },
+      navigate(page: PageName, options: Partial<NavState> = {}) {
+        deps.navigate(page, options);
+      },
+      showToast(message: string, type: "success" | "error" = "success") {
+        deps.showToast(message, type);
+      },
+      markDirty() {
+        deps.markDirty?.();
+      }
+    };
+  };
+
+  const buildContext = (modId: string) => {
+    return {
+      modId,
+      appVersion: APP_VERSION,
+      schemaVersion: SCHEMA_VERSION,
+      api: createStoreAPI(modId)
+    };
+  };
+
+  const ensureRegistered = (modId: string, modData: ModData): ModRegistryEntry | null => {
+    if (registry[modId]?.__loaded) {
+      return registry[modId];
+    }
+    try {
+      registry[modId] = registry[modId] || { id: modId, hooks: {}, meta: {} };
+      const sourceURL = `\n//# sourceURL=${modId}.mod.js`;
+      const runner = new Function("window", "document", "CIB_MODS", "storeAPI", "console", (modData.js || "") + sourceURL);
+      const storeAPI = createStoreAPI(modId);
+      runner(window, document, runtime, storeAPI, console);
+      if (modData.meta) {
+        registry[modId].meta = { ...modData.meta };
+      }
+      registry[modId].__loaded = true;
+      return registry[modId];
+    } catch (err) {
+      console.error(`[Mods] Failed to evaluate ${modId}:`, err);
+      registry[modId] = registry[modId] || { id: modId, hooks: {}, meta: modData?.meta || {} };
+      registry[modId].__loaded = false;
+      registry[modId].__error = err;
+      return null;
+    }
+  };
+
+  const runtime: ModRuntime = {
+    registry,
+    _registry: registry,
+    register(modId, definition = {}) {
+      if (!modId) throw new Error("CIB_MODS.register requires a mod id");
+      const entry = registry[modId] || { id: modId, hooks: {}, meta: {} };
+      entry.hooks = {
+        onAppInit: typeof definition.onAppInit === "function" ? definition.onAppInit : entry.hooks.onAppInit,
+        onCardRender: typeof definition.onCardRender === "function" ? definition.onCardRender : entry.hooks.onCardRender,
+        onCardSave: typeof definition.onCardSave === "function" ? definition.onCardSave : entry.hooks.onCardSave,
+        onCardDelete: typeof definition.onCardDelete === "function" ? definition.onCardDelete : entry.hooks.onCardDelete
+      };
+      if (definition.meta) {
+        entry.meta = { ...definition.meta };
+      }
+      registry[modId] = entry;
+      entry.__loaded = true;
+      return entry;
+    },
+    enable(modId, modData) {
+      if (!modData) return false;
+      ensureStyle(modId, modData.css);
+      const entry = ensureRegistered(modId, modData);
+      if (!entry) return false;
+      initializedMods.delete(modId);
+      return true;
+    },
+    disable(modId) {
+      removeStyle(modId);
+      initializedMods.delete(modId);
+      return true;
+    },
+    syncFromStore(store) {
+      Object.keys(registry).forEach((modId) => {
+        if (!store.mods[modId]) {
+          removeStyle(modId);
+          initializedMods.delete(modId);
+          delete registry[modId];
+        }
+      });
+      Object.entries(store.mods).forEach(([modId, modData]) => {
+        if (!modData) return;
+        if (modData.enabled) {
+          ensureStyle(modId, modData.css);
+          ensureRegistered(modId, modData);
+        } else {
+          removeStyle(modId);
+        }
+      });
+    },
+    runHook(name, ...args) {
+      const store = deps.getStore();
+      Object.entries(store.mods).forEach(([modId, modData]) => {
+        if (!modData?.enabled) return;
+        const entry = ensureRegistered(modId, modData);
+        if (!entry) return;
+        if (name === "onAppInit" && initializedMods.has(modId)) return;
+        const fn = entry.hooks?.[name];
+        if (typeof fn === "function") {
+          try {
+            const context = buildContext(modId);
+            fn(...args, context);
+            if (name === "onAppInit") {
+              initializedMods.add(modId);
+            }
+          } catch (err) {
+            console.error(`[Mods] ${modId} ${name} hook failed:`, err);
+          }
+        }
+      });
+    }
+  };
+
+  if (typeof window !== "undefined") {
+    (window as any).CIB_MODS = runtime;
+  }
+
+  return runtime;
+}

--- a/figma/src/lib/store.ts
+++ b/figma/src/lib/store.ts
@@ -1,0 +1,610 @@
+import {
+  AppendTXTResult,
+  Card,
+  CardID,
+  ExportPackage,
+  InstallModResult,
+  ModData,
+  ModSummary,
+  NormalizedModPackage,
+  StoreShape,
+  TXTImportResult
+} from "./types";
+
+export const APP_VERSION = "0.6.9.13";
+export const SCHEMA_VERSION = 3;
+
+export const DEFAULT_STORE: StoreShape = {
+  rootOrder: [],
+  cards: {},
+  mods: {}
+};
+
+export function createEmptyStore(): StoreShape {
+  return {
+    rootOrder: [],
+    cards: {},
+    mods: {}
+  };
+}
+
+export function cloneCard(card: Card | undefined | null): Card | null {
+  if (!card) return null;
+  let modsData: Record<string, unknown> = {};
+  if (card.modsData) {
+    try {
+      modsData = JSON.parse(JSON.stringify(card.modsData));
+    } catch {
+      modsData = { ...card.modsData };
+    }
+  }
+
+  return {
+    ...card,
+    children: Array.isArray(card.children) ? [...card.children] : [],
+    modsData
+  };
+}
+
+export function cloneStore(store: StoreShape): StoreShape {
+  const cards: Record<CardID, Card> = {};
+  Object.entries(store.cards).forEach(([id, card]) => {
+    cards[id] = {
+      ...card,
+      children: [...(card.children || [])],
+      modsData: card.modsData ? JSON.parse(JSON.stringify(card.modsData)) : {}
+    };
+  });
+
+  const mods: Record<string, ModData> = {};
+  Object.entries(store.mods || {}).forEach(([id, mod]) => {
+    mods[id] = {
+      enabled: !!mod.enabled,
+      js: mod.js,
+      css: mod.css,
+      meta: { ...(mod.meta || {}) }
+    };
+  });
+
+  return {
+    rootOrder: [...store.rootOrder],
+    cards,
+    mods
+  };
+}
+
+export function loadStore(instanceKey: string | null): StoreShape {
+  const key = instanceKey || "nested_cards_store";
+  try {
+    const raw = localStorage.getItem(key);
+    if (!raw) {
+      return createEmptyStore();
+    }
+    const parsed = JSON.parse(raw);
+    return {
+      rootOrder: Array.isArray(parsed.rootOrder) ? parsed.rootOrder : [],
+      cards: parsed.cards ?? {},
+      mods: parsed.mods ?? {}
+    };
+  } catch {
+    return createEmptyStore();
+  }
+}
+
+export function saveStore(store: StoreShape, instanceKey: string | null) {
+  const key = instanceKey || "nested_cards_store";
+  localStorage.setItem(key, JSON.stringify(store));
+}
+
+export function getInstanceNames(): string[] {
+  try {
+    const raw = localStorage.getItem("cib_instances");
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter((v) => typeof v === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+export function setInstanceNames(names: string[]) {
+  localStorage.setItem("cib_instances", JSON.stringify(names));
+}
+
+export function createCard(store: StoreShape, title: string, body: string, parentId: CardID | null): Card {
+  const id = `card-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  const card: Card = {
+    id,
+    title: title || "(Untitled)",
+    body: body || "",
+    parentId: parentId || null,
+    children: [],
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    modsData: {}
+  };
+
+  store.cards[id] = card;
+  if (parentId) {
+    const parent = store.cards[parentId];
+    if (parent) {
+      parent.children.push(id);
+    }
+  } else {
+    store.rootOrder.push(id);
+  }
+
+  return card;
+}
+
+export function updateCard(store: StoreShape, id: CardID, updates: Partial<Omit<Card, "id" | "children">> & { children?: CardID[] })
+: Card | null {
+  const card = store.cards[id];
+  if (!card) return null;
+  const oldParent = card.parentId;
+  Object.assign(card, updates, { updatedAt: Date.now() });
+  const newParent = card.parentId;
+
+  if (updates.children) {
+    card.children = [...updates.children];
+  }
+
+  if (oldParent !== newParent) {
+    if (oldParent) {
+      const parent = store.cards[oldParent];
+      if (parent) {
+        parent.children = parent.children.filter((cid) => cid !== id);
+      }
+    } else {
+      store.rootOrder = store.rootOrder.filter((cid) => cid !== id);
+    }
+
+    if (newParent) {
+      const parent = store.cards[newParent];
+      if (parent && !parent.children.includes(id)) {
+        parent.children.push(id);
+      }
+    } else if (!store.rootOrder.includes(id)) {
+      store.rootOrder.push(id);
+    }
+  }
+
+  return card;
+}
+
+export function deleteCard(store: StoreShape, id: CardID) {
+  const card = store.cards[id];
+  if (!card) return;
+  const children = [...card.children];
+  children.forEach((childId) => deleteCard(store, childId));
+
+  if (card.parentId) {
+    const parent = store.cards[card.parentId];
+    if (parent) {
+      parent.children = parent.children.filter((cid) => cid !== id);
+    }
+  } else {
+    store.rootOrder = store.rootOrder.filter((cid) => cid !== id);
+  }
+
+  delete store.cards[id];
+}
+
+export function cardPath(store: StoreShape, cardId: CardID | null): CardID[] {
+  const path: CardID[] = [];
+  let current = cardId;
+  while (current) {
+    path.unshift(current);
+    const card = store.cards[current];
+    current = card?.parentId ?? null;
+  }
+  return path;
+}
+
+export function buildPackage(store: StoreShape, rootIds: CardID[], exportType: ExportPackage["exportType"]): ExportPackage {
+  const cards: Record<CardID, Card> = {};
+  const walk = (id: CardID) => {
+    const card = store.cards[id];
+    if (!card || cards[id]) return;
+    cards[id] = cloneCard(card)!;
+    card.children.forEach(walk);
+  };
+  rootIds.forEach(walk);
+
+  const pkg: ExportPackage = {
+    version: APP_VERSION,
+    exportType,
+    rootIds: [...rootIds],
+    cards
+  };
+
+  if (exportType === "instance") {
+    pkg.mods = JSON.parse(JSON.stringify(store.mods || {}));
+  }
+
+  return pkg;
+}
+
+export function exportTXT(store: StoreShape, rootIds: CardID[]): string {
+  const sortByTitle = (ids: CardID[]) => {
+    return [...ids].sort((a, b) => {
+      const cardA = store.cards[a];
+      const cardB = store.cards[b];
+      const titleA = (cardA?.title || "").toLowerCase();
+      const titleB = (cardB?.title || "").toLowerCase();
+      return titleA.localeCompare(titleB);
+    });
+  };
+
+  const blockForCard = (id: CardID, depth = 0): string => {
+    const card = store.cards[id];
+    if (!card) return "";
+    const pad = " ".repeat(depth * 2);
+    const pad2 = " ".repeat((depth + 1) * 2);
+    let out = `${pad}Card: ${card.title || "(Untitled)"}\n`;
+    out += `${pad}Details:\n`;
+    if (!card.body) {
+      out += `${pad2}(none)\n`;
+    } else {
+      const bodyLines = card.body.split("\n");
+      if (bodyLines.length === 0) {
+        out += `${pad2}(none)\n`;
+      } else {
+        bodyLines.forEach((line) => {
+          out += `${pad2}${line}\n`;
+        });
+      }
+    }
+
+    const children = sortByTitle(card.children || []);
+    out += `${pad}Children:\n`;
+    if (children.length === 0) {
+      out += `${pad2}(none)\n`;
+    } else {
+      children.forEach((childId) => {
+        out += `${pad2}- Card: ${(store.cards[childId]?.title || "(Untitled)")}\n`;
+        out += blockForCard(childId, depth + 2);
+      });
+    }
+    return out;
+  };
+
+  const lines: string[] = [];
+  const rootsSorted = sortByTitle(rootIds);
+  rootsSorted.forEach((rid, idx) => {
+    const block = blockForCard(rid, 0).trimEnd();
+    if (block) lines.push(block);
+    if (idx < rootsSorted.length - 1) {
+      lines.push("\n");
+    }
+  });
+
+  return lines.join("\n");
+}
+
+export interface ParsedTXTCard {
+  title: string;
+  body: string;
+  children: ParsedTXTCard[];
+  depth: number;
+}
+
+export function parseTXT(text: string): ParsedTXTCard[] {
+  const lines = text.split("\n");
+  const cards: ParsedTXTCard[] = [];
+  const stack: ParsedTXTCard[] = [];
+
+  let currentCard: ParsedTXTCard | null = null;
+  let currentSection: "title" | "details" | "children" | null = null;
+  let detailsBuffer: string[] = [];
+
+  const flushDetails = () => {
+    if (currentCard && detailsBuffer.length > 0) {
+      currentCard.body = detailsBuffer.join("\n").trim();
+      detailsBuffer = [];
+    }
+  };
+
+  lines.forEach((line) => {
+    if (!line.trim()) {
+      if (currentSection === "details" && detailsBuffer.length > 0) {
+        detailsBuffer.push("");
+      }
+      return;
+    }
+
+    const indent = line.search(/\S/);
+    const depth = Math.floor(indent / 2);
+    const content = line.trim();
+
+    if (content.startsWith("Card:") || content.startsWith("- Card:")) {
+      flushDetails();
+      const title = content.replace(/^-?\s*Card:\s*/, "").trim();
+      currentCard = {
+        title: title || "(Imported)",
+        body: "",
+        children: [],
+        depth
+      };
+
+      if (depth === 0) {
+        cards.push(currentCard);
+      } else {
+        while (stack.length > depth) {
+          stack.pop();
+        }
+        const parent = stack[stack.length - 1];
+        if (parent) {
+          parent.children.push(currentCard);
+        }
+      }
+
+      while (stack.length > depth) {
+        stack.pop();
+      }
+      stack.push(currentCard);
+      currentSection = "title";
+      return;
+    }
+
+    if (content === "Details:") {
+      currentSection = "details";
+      detailsBuffer = [];
+      return;
+    }
+
+    if (content === "Children:") {
+      flushDetails();
+      currentSection = "children";
+      return;
+    }
+
+    if (currentSection === "details") {
+      detailsBuffer.push(content);
+    }
+  });
+
+  flushDetails();
+  return cards;
+}
+
+export function importTXTOutline(store: StoreShape, text: string, parentId: CardID | null): TXTImportResult {
+  const parsedCards = parseTXT(text);
+  const createdIds: CardID[] = [];
+
+  const createRecursive = (cardData: ParsedTXTCard, parent: CardID | null) => {
+    const card = createCard(store, cardData.title, cardData.body, parent);
+    createdIds.push(card.id);
+    cardData.children.forEach((child) => createRecursive(child, card.id));
+  };
+
+  parsedCards.forEach((card) => createRecursive(card, parentId));
+
+  return {
+    success: true,
+    cardCount: createdIds.length,
+    rootIds: createdIds
+  };
+}
+
+export function appendTXTToDetails(store: StoreShape, cardId: CardID, text: string): AppendTXTResult {
+  const card = store.cards[cardId];
+  if (!card) {
+    return { success: false, error: "Card not found" };
+  }
+  card.body = card.body ? `${card.body}\n\n${text}` : text;
+  card.updatedAt = Date.now();
+  return { success: true, cardId };
+}
+
+export function validateImport(pkg: ExportPackage | any): { valid: boolean; error: string | null } {
+  if (!pkg || typeof pkg !== "object") {
+    return { valid: false, error: "Invalid JSON structure" };
+  }
+  if (!pkg.version) {
+    return { valid: false, error: "Missing version field" };
+  }
+  if (!pkg.exportType || !["card", "subtree", "instance"].includes(pkg.exportType)) {
+    return { valid: false, error: "Invalid or missing exportType" };
+  }
+  if (!pkg.cards || typeof pkg.cards !== "object") {
+    return { valid: false, error: "Missing or invalid cards object" };
+  }
+  if (!pkg.rootIds || !Array.isArray(pkg.rootIds)) {
+    return { valid: false, error: "Missing or invalid rootIds array" };
+  }
+  if (Object.keys(pkg.cards).length === 0) {
+    return { valid: false, error: "No cards found in import" };
+  }
+  for (const [cardId, card] of Object.entries(pkg.cards as Record<string, Card>)) {
+    if (!(card as Card).id) {
+      return { valid: false, error: `Card missing id field: ${cardId}` };
+    }
+    if ((card as Card).title === undefined) {
+      return { valid: false, error: `Card missing title field: ${cardId}` };
+    }
+    if (!Array.isArray((card as Card).children)) {
+      return { valid: false, error: `Card has invalid children array: ${cardId}` };
+    }
+  }
+  return { valid: true, error: null };
+}
+
+export function remapIds(pkg: ExportPackage) {
+  const idMap: Record<string, CardID> = {};
+  Object.keys(pkg.cards).forEach((oldId) => {
+    idMap[oldId] = `card-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+  });
+
+  const newCards: Record<CardID, Card> = {};
+  Object.entries(pkg.cards).forEach(([oldId, card]) => {
+    const newId = idMap[oldId];
+    const remappedChildren = (card.children || []).map((childId) => idMap[childId]).filter(Boolean);
+    newCards[newId] = {
+      ...card,
+      id: newId,
+      parentId: card.parentId ? idMap[card.parentId] || null : null,
+      children: remappedChildren,
+      createdAt: card.createdAt || Date.now(),
+      updatedAt: Date.now(),
+      modsData: card.modsData || {}
+    };
+  });
+
+  const newRootIds = pkg.rootIds.map((oldId) => idMap[oldId]).filter(Boolean);
+
+  return {
+    ...pkg,
+    cards: newCards,
+    rootIds: newRootIds,
+    idMap
+  };
+}
+
+export function importJSON(
+  store: StoreShape,
+  pkg: ExportPackage,
+  mode: "root" | CardID
+): { success: boolean; cardCount: number; importedIds: CardID[]; rootIds: CardID[] } {
+  const remapped = remapIds(pkg);
+  const importedIds = Object.keys(remapped.cards);
+
+  Object.entries(remapped.cards).forEach(([cardId, card]) => {
+    store.cards[cardId] = card;
+  });
+
+  if (mode === "root") {
+    remapped.rootIds.forEach((cardId) => {
+      if (store.cards[cardId] && !store.rootOrder.includes(cardId)) {
+        store.rootOrder.push(cardId);
+      }
+    });
+  } else {
+    const parent = store.cards[mode];
+    if (parent) {
+      remapped.rootIds.forEach((cardId) => {
+        const card = store.cards[cardId];
+        if (card) {
+          card.parentId = mode;
+          if (!parent.children.includes(cardId)) {
+            parent.children.push(cardId);
+          }
+        }
+      });
+    }
+  }
+
+  if (pkg.exportType === "instance" && pkg.mods) {
+    Object.entries(pkg.mods).forEach(([modId, mod]) => {
+      if (!store.mods[modId]) {
+        store.mods[modId] = {
+          enabled: !!mod.enabled,
+          js: mod.js || "",
+          css: mod.css || "",
+          meta: mod.meta ? { ...mod.meta } : {}
+        };
+      }
+    });
+  }
+
+  return {
+    success: true,
+    cardCount: importedIds.length,
+    importedIds,
+    rootIds: remapped.rootIds
+  };
+}
+
+export function normalizeModPackage(raw: unknown):
+  | { success: true; pkg: NormalizedModPackage }
+  | { success: false; error: string } {
+  const toStr = (value: unknown) => (typeof value === "string" ? value.trim() : "");
+  if (!raw || typeof raw !== "object") {
+    return { success: false, error: "Invalid mod package structure" };
+  }
+  const source = raw as Record<string, unknown>;
+  const modId = toStr(source.id) || toStr(source.modId);
+  if (!modId) {
+    return { success: false, error: "Extension package is missing an id" };
+  }
+  const js = toStr(source.js);
+  if (!js.trim()) {
+    return { success: false, error: "Extension package must include JavaScript" };
+  }
+  const css = toStr(source.css);
+  const enabled = source.enabled === undefined ? true : !!source.enabled;
+  const metaSource = typeof source.meta === "object" && source.meta !== null ? (source.meta as Record<string, unknown>) : {};
+  const meta = {
+    name: toStr(metaSource.name) || toStr(source.name),
+    version: toStr(metaSource.version) || toStr(source.version),
+    author: toStr(metaSource.author) || toStr(source.author),
+    description: toStr(metaSource.description) || toStr(source.description)
+  };
+  return {
+    success: true,
+    pkg: {
+      modId,
+      js,
+      css,
+      enabled,
+      meta
+    }
+  };
+}
+
+export function installModPackage(store: StoreShape, raw: unknown, source: string = "upload"): InstallModResult {
+  const normalized = normalizeModPackage(raw);
+  if (!normalized.success) {
+    return { success: false, error: normalized.error };
+  }
+
+  const { modId, js, css, enabled, meta } = normalized.pkg;
+  if (store.mods[modId]) {
+    const proceed = typeof window !== "undefined" ? window.confirm(`Extension "${modId}" already exists. Replace it?`) : true;
+    if (!proceed) {
+      return { success: false, cancelled: true };
+    }
+  }
+
+  store.mods[modId] = {
+    enabled: !!enabled,
+    js,
+    css,
+    meta: { ...meta }
+  };
+
+  return { success: true, modId, source };
+}
+
+export function getModSummary(modId: string, modData: ModData | undefined): ModSummary {
+  const meta = modData?.meta || {};
+  const parts: string[] = [];
+  if (meta.version) parts.push(`v${meta.version}`);
+  if (meta.author) parts.push(meta.author);
+  return {
+    title: meta.name ? `${meta.name}` : modId,
+    subtitle: parts.join(" • "),
+    description: meta.description || ""
+  };
+}
+
+export function toggleMod(store: StoreShape, modId: string): ModData | null {
+  const mod = store.mods[modId];
+  if (!mod) return null;
+  mod.enabled = !mod.enabled;
+  return mod;
+}
+
+export function removeMod(store: StoreShape, modId: string): boolean {
+  if (!store.mods[modId]) return false;
+  delete store.mods[modId];
+  return true;
+}
+
+export function searchCards(store: StoreShape, query: string): Card[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) return [];
+  return Object.values(store.cards)
+    .filter((card) => (card.title + " " + card.body).toLowerCase().includes(normalized))
+    .sort((a, b) => (a.title || "").toLowerCase().localeCompare((b.title || "").toLowerCase()));
+}

--- a/figma/src/lib/types.ts
+++ b/figma/src/lib/types.ts
@@ -1,0 +1,83 @@
+export type CardID = string;
+
+export interface Card {
+  id: CardID;
+  title: string;
+  body: string;
+  parentId: CardID | null;
+  children: CardID[];
+  createdAt: number;
+  updatedAt: number;
+  modsData?: Record<string, unknown>;
+}
+
+export interface ModMeta {
+  name?: string;
+  version?: string;
+  author?: string;
+  description?: string;
+}
+
+export interface ModData {
+  enabled: boolean;
+  js: string;
+  css: string;
+  meta: ModMeta;
+}
+
+export interface StoreShape {
+  rootOrder: CardID[];
+  cards: Record<CardID, Card>;
+  mods: Record<string, ModData>;
+}
+
+export type PageName = "list" | "read" | "edit" | "search";
+
+export interface NavState {
+  page: PageName;
+  cardId: CardID | null;
+  parentId: CardID | null;
+  searchQuery: string;
+}
+
+export interface ExportPackage {
+  version: string;
+  exportType: "card" | "subtree" | "instance";
+  rootIds: CardID[];
+  cards: Record<CardID, Card>;
+  mods?: Record<string, ModData>;
+}
+
+export interface TXTImportResult {
+  success: boolean;
+  cardCount: number;
+  rootIds: CardID[];
+}
+
+export interface AppendTXTResult {
+  success: boolean;
+  error?: string;
+  cardId?: CardID;
+}
+
+export interface InstallModResult {
+  success: boolean;
+  modId?: string;
+  error?: string;
+  cancelled?: boolean;
+  source?: string;
+}
+
+export interface ModSummary {
+  title: string;
+  subtitle: string;
+  description: string;
+}
+
+export interface NormalizedModPackage {
+  modId: string;
+  js: string;
+  css: string;
+  enabled: boolean;
+  meta: ModMeta;
+}

--- a/figma/src/main.tsx
+++ b/figma/src/main.tsx
@@ -1,0 +1,7 @@
+
+  import { createRoot } from "react-dom/client";
+  import App from "./App.tsx";
+  import "./index.css";
+
+  createRoot(document.getElementById("root")!).render(<App />);
+  

--- a/figma/src/styles/globals.css
+++ b/figma/src/styles/globals.css
@@ -1,0 +1,212 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Outfit:wght@300;400;500;600;700;800&display=swap');
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --font-size: 18px;
+  --background: #FFFFFF;
+  --foreground: #111111;
+  --card: #FFFFFF;
+  --card-foreground: #111111;
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.145 0 0);
+  --primary: #111111;
+  --primary-foreground: #FFFFFF;
+  --secondary: oklch(0.98 0.0058 264.53);
+  --secondary-foreground: #111111;
+  --muted: #FAFAFA;
+  --muted-foreground: #666666;
+  --accent: #F5F5F5;
+  --accent-foreground: #111111;
+  --destructive: #d4183d;
+  --destructive-foreground: #ffffff;
+  --border: rgba(0, 0, 0, 0.08);
+  --input: transparent;
+  --input-background: #FFFFFF;
+  --switch-background: #cbced4;
+  --font-weight-light: 300;
+  --font-weight-medium: 500;
+  --font-weight-normal: 400;
+  --font-weight-bold: 700;
+  --ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
+  --radius: 0.25rem;
+  --sidebar: oklch(0.985 0 0);
+  --sidebar-foreground: oklch(0.145 0 0);
+  --sidebar-primary: #111111;
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.205 0 0);
+  --sidebar-border: oklch(0.922 0 0);
+  --sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+  --background: oklch(0.145 0 0);
+  --foreground: oklch(0.985 0 0);
+  --card: oklch(0.145 0 0);
+  --card-foreground: oklch(0.985 0 0);
+  --popover: oklch(0.145 0 0);
+  --popover-foreground: oklch(0.985 0 0);
+  --primary: oklch(0.985 0 0);
+  --primary-foreground: oklch(0.205 0 0);
+  --secondary: oklch(0.269 0 0);
+  --secondary-foreground: oklch(0.985 0 0);
+  --muted: oklch(0.269 0 0);
+  --muted-foreground: oklch(0.708 0 0);
+  --accent: oklch(0.269 0 0);
+  --accent-foreground: oklch(0.985 0 0);
+  --destructive: oklch(0.396 0.141 25.723);
+  --destructive-foreground: oklch(0.637 0.237 25.331);
+  --border: oklch(0.269 0 0);
+  --input: oklch(0.269 0 0);
+  --ring: oklch(0.439 0 0);
+  --font-weight-medium: 500;
+  --font-weight-normal: 400;
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
+  --sidebar: oklch(0.205 0 0);
+  --sidebar-foreground: oklch(0.985 0 0);
+  --sidebar-primary: oklch(0.488 0.243 264.376);
+  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-accent: oklch(0.269 0 0);
+  --sidebar-accent-foreground: oklch(0.985 0 0);
+  --sidebar-border: oklch(0.269 0 0);
+  --sidebar-ring: oklch(0.439 0 0);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-input-background: var(--input-background);
+  --color-switch-background: var(--switch-background);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+}
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+    font-family: 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+}
+
+/**
+ * Base typography. This is not applied to elements which have an ancestor with a Tailwind text class.
+ */
+@layer base {
+  :where(:not(:has([class*=' text-']), :not(:has([class^='text-'])))) {
+    h1 {
+      font-family: 'Inter', 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 96px;
+      font-weight: 700;
+      line-height: 1.0;
+      letter-spacing: -0.03em;
+    }
+
+    h2 {
+      font-family: 'Inter', 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 72px;
+      font-weight: 700;
+      line-height: 1.0;
+      letter-spacing: -0.04em;
+    }
+
+    h3 {
+      font-family: 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 32px;
+      font-weight: 700;
+      line-height: 1.15;
+      letter-spacing: -0.025em;
+    }
+
+    h4 {
+      font-family: 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 20px;
+      font-weight: 600;
+      line-height: 1.3;
+      letter-spacing: -0.02em;
+    }
+
+    p {
+      font-family: 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 16px;
+      font-weight: 400;
+      line-height: 1.7;
+      letter-spacing: -0.01em;
+    }
+
+    label {
+      font-family: 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 14px;
+      font-weight: 500;
+      line-height: 1.4;
+      letter-spacing: -0.01em;
+    }
+
+    button {
+      font-family: 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 15px;
+      font-weight: 500;
+      line-height: 1.5;
+      letter-spacing: -0.01em;
+    }
+
+    input {
+      font-family: 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 16px;
+      font-weight: 400;
+      line-height: 1.5;
+      letter-spacing: -0.01em;
+    }
+  }
+}
+
+html {
+  font-size: var(--font-size);
+}

--- a/figma/src/views/CardDetailView.tsx
+++ b/figma/src/views/CardDetailView.tsx
@@ -1,0 +1,145 @@
+import { CardID, StoreShape } from "../lib/types";
+import { formatDate, bodyPreview } from "../lib/format";
+import { Button } from "../components/ui/button";
+import { MoreHorizontal } from "lucide-react";
+import { SimpleMenu } from "../components/SimpleMenu";
+
+interface CardDetailViewProps {
+  store: StoreShape;
+  cardId: CardID;
+  onEdit: (cardId: CardID) => void;
+  onAddChild: (cardId: CardID) => void;
+  onViewChildren: (cardId: CardID) => void;
+  onViewParent: (cardId: CardID | null) => void;
+  onOpenCard: (cardId: CardID) => void;
+  onExport: (cardId: CardID, exportType: "card-json" | "card-txt" | "subtree-json" | "subtree-txt") => void;
+  onUploadToCard: (cardId: CardID) => void;
+  onCardRender: (cardId: CardID, element: HTMLElement | null) => void;
+}
+
+export function CardDetailView({
+  store,
+  cardId,
+  onEdit,
+  onAddChild,
+  onViewChildren,
+  onViewParent,
+  onOpenCard,
+  onExport,
+  onUploadToCard,
+  onCardRender
+}: CardDetailViewProps) {
+  const card = store.cards[cardId];
+  if (!card) {
+    return <div className="text-muted-foreground">Card not found.</div>;
+  }
+
+  const parent = card.parentId ? store.cards[card.parentId] : null;
+  const children = card.children.map((childId) => store.cards[childId]).filter(Boolean);
+
+  return (
+    <section className="space-y-12" ref={(el) => onCardRender(card.id, el)}>
+      <header className="space-y-6">
+        <div className="space-y-2">
+          <h2 className="text-5xl font-semibold text-foreground">{card.title || "(Untitled)"}</h2>
+          {parent && (
+            <button
+              className="text-sm uppercase tracking-[0.3em] text-muted-foreground transition hover:text-foreground"
+              onClick={() => onViewParent(parent.id)}
+            >
+              Parent · {parent.title || "(Untitled)"}
+            </button>
+          )}
+        </div>
+        <div className="rounded-[36px] bg-muted/20 p-8 text-lg leading-relaxed text-muted-foreground">
+          {card.body || "No details available yet."}
+        </div>
+      </header>
+
+      <div className="grid gap-8 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <div className="space-y-4">
+          <h3 className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Actions</h3>
+          <div className="flex flex-wrap gap-3">
+            <Button onClick={() => onEdit(card.id)}>Edit Card</Button>
+            <Button variant="secondary" onClick={() => onAddChild(card.id)}>
+              + Add Child
+            </Button>
+            <Button variant="ghost" onClick={() => onUploadToCard(card.id)}>
+              Upload to Card
+            </Button>
+            <div
+              onClick={(event) => event.stopPropagation()}
+              onKeyDown={(event) => event.stopPropagation()}
+              role="presentation"
+            >
+              <SimpleMenu
+                triggerIcon={<MoreHorizontal className="h-4 w-4" />}
+                triggerLabel="Card export menu"
+                triggerClassName="h-11 w-11 rounded-full bg-foreground/10 text-foreground hover:bg-foreground/20"
+                items={[
+                  { label: "Download Card (JSON)", onSelect: () => onExport(card.id, "card-json") },
+                  { label: "Download Card (TXT)", onSelect: () => onExport(card.id, "card-txt") },
+                  { label: "Download Card + Children (JSON)", onSelect: () => onExport(card.id, "subtree-json") },
+                  { label: "Download Card + Children (TXT)", onSelect: () => onExport(card.id, "subtree-txt") }
+                ]}
+                menuClassName="w-72"
+              />
+            </div>
+            <Button variant="ghost" onClick={() => onViewChildren(card.id)}>
+              View All Children
+            </Button>
+            <Button variant="ghost" onClick={() => onViewParent(card.parentId ?? null)}>
+              View Siblings
+            </Button>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <h3 className="text-sm uppercase tracking-[0.3em] text-muted-foreground">Metadata</h3>
+          <div className="rounded-[32px] bg-muted/15 p-6">
+            <dl className="space-y-3 text-sm text-foreground/90">
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">Created</dt>
+                <dd>{formatDate(card.createdAt)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">Updated</dt>
+                <dd>{formatDate(card.updatedAt)}</dd>
+              </div>
+              <div className="flex justify-between">
+                <dt className="text-muted-foreground">Children</dt>
+                <dd>{card.children.length}</dd>
+              </div>
+            </dl>
+          </div>
+        </div>
+      </div>
+
+      <section className="space-y-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h3 className="text-lg font-medium text-foreground">Children</h3>
+          <Button variant="secondary" onClick={() => onAddChild(card.id)}>
+            + Add Child
+          </Button>
+        </div>
+        {children.length === 0 ? (
+          <div className="rounded-[32px] bg-muted/20 px-6 py-12 text-muted-foreground">No children yet.</div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {children.map((child) => (
+              <button
+                key={child!.id}
+                className="rounded-[32px] bg-card/85 p-6 text-left text-foreground shadow-[0_24px_60px_rgba(17,17,17,0.08)] transition hover:-translate-y-0.5 hover:shadow-[0_32px_90px_rgba(17,17,17,0.12)]"
+                onClick={() => onOpenCard(child!.id)}
+                ref={(el) => onCardRender(child!.id, el)}
+              >
+                <div className="font-medium text-foreground">{child!.title || "(Untitled)"}</div>
+                <div className="mt-2 text-sm text-muted-foreground">{bodyPreview(child!.body, 120)}</div>
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/figma/src/views/CardFormView.tsx
+++ b/figma/src/views/CardFormView.tsx
@@ -1,0 +1,198 @@
+import { useMemo, useState } from "react";
+import { Button } from "../components/ui/button";
+import { Textarea } from "../components/ui/textarea";
+import { Input } from "../components/ui/input";
+import { CardID, StoreShape } from "../lib/types";
+
+export interface CardFormPayload {
+  title: string;
+  body: string;
+  parentId: CardID | null;
+  renamedChildren: Record<CardID, string>;
+  removedChildren: CardID[];
+  newChildren: string[];
+}
+
+interface CardFormViewProps {
+  store: StoreShape;
+  cardId: CardID | null;
+  parentId: CardID | null;
+  onSubmit: (payload: CardFormPayload) => void;
+  onCancel: () => void;
+  onDelete?: (cardId: CardID) => void;
+}
+
+export function CardFormView({ store, cardId, parentId, onSubmit, onCancel, onDelete }: CardFormViewProps) {
+  const editing = !!cardId;
+  const card = editing ? store.cards[cardId!] : null;
+
+  const [title, setTitle] = useState(card?.title || "");
+  const [body, setBody] = useState(card?.body || "");
+  const [selectedParent, setSelectedParent] = useState<CardID | "" | null>(card?.parentId ?? parentId ?? null);
+  const [renamedChildren, setRenamedChildren] = useState<Record<CardID, string>>({});
+  const [removedChildren, setRemovedChildren] = useState<CardID[]>([]);
+  const [newChildren, setNewChildren] = useState<string[]>([""]);
+
+  const availableParents = useMemo(() => {
+    const entries = Object.values(store.cards);
+    if (!editing || !card) {
+      return entries;
+    }
+
+    const isDescendant = (potentialParent: CardID): boolean => {
+      if (potentialParent === card.id) return true;
+      const target = store.cards[potentialParent];
+      if (!target) return false;
+      if (target.children.includes(card.id)) return true;
+      return target.children.some((childId) => isDescendant(childId));
+    };
+
+    return entries.filter((candidate) => candidate.id !== card.id && !isDescendant(candidate.id));
+  }, [store.cards, editing, card]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    onSubmit({
+      title: title.trim() || "(Untitled)",
+      body: body.trim(),
+      parentId: selectedParent ? (selectedParent === "" ? null : selectedParent) : null,
+      renamedChildren,
+      removedChildren,
+      newChildren: newChildren.map((entry) => entry.trim()).filter(Boolean)
+    });
+  };
+
+  const toggleRemoveChild = (childId: CardID) => {
+    setRemovedChildren((current) =>
+      current.includes(childId) ? current.filter((id) => id !== childId) : [...current, childId]
+    );
+  };
+
+  const heading = editing ? "Edit Card" : "Create Card";
+
+  return (
+    <section className="max-w-3xl space-y-10">
+      <header className="space-y-3">
+        <h2 className="text-5xl font-semibold text-foreground">{heading}</h2>
+        <p className="text-base text-muted-foreground">
+          {editing ? "Update the details and structure of this card." : "Define the top-level information for your new card."}
+        </p>
+      </header>
+
+      <form className="space-y-8" onSubmit={handleSubmit}>
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Title</label>
+          <Input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="Card title" />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Details</label>
+          <Textarea
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+            placeholder="Add your notes, context, or reference material here."
+            rows={10}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Parent Card</label>
+          <select
+            className="w-full rounded-full border border-transparent bg-muted/25 px-5 py-3 text-base text-foreground transition focus:border-foreground/20 focus:bg-muted/35 focus:outline-none"
+            value={selectedParent ?? ""}
+            onChange={(event) => {
+              const value = event.target.value as CardID | "";
+              setSelectedParent(value === "" ? null : value);
+            }}
+          >
+            <option value="">No parent (top-level)</option>
+            {availableParents
+              .sort((a, b) => (a.title || "").localeCompare(b.title || ""))
+              .map((entry) => (
+                <option key={entry.id} value={entry.id}>
+                  {entry.title || "(Untitled)"}
+                </option>
+              ))}
+          </select>
+        </div>
+
+        {editing && card && card.children.length > 0 && (
+          <div className="space-y-4 rounded-[32px] bg-muted/15 p-6">
+            <h3 className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Existing Children</h3>
+            <div className="space-y-3">
+              {card.children.map((childId) => {
+                const child = store.cards[childId];
+                if (!child) return null;
+                const markedForRemoval = removedChildren.includes(childId);
+                return (
+                  <div key={childId} className="flex flex-wrap items-center gap-3">
+                    <Input
+                      value={renamedChildren[childId] ?? child.title ?? ""}
+                      onChange={(event) =>
+                        setRenamedChildren((current) => ({ ...current, [childId]: event.target.value }))
+                      }
+                      disabled={markedForRemoval}
+                    />
+                    <label className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <input
+                        type="checkbox"
+                        checked={markedForRemoval}
+                        onChange={() => toggleRemoveChild(childId)}
+                      />
+                      Remove
+                    </label>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          <h3 className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Add New Children</h3>
+          <div className="space-y-3">
+            {newChildren.map((value, index) => (
+              <div key={index} className="flex flex-wrap gap-2">
+                <Input
+                  value={value}
+                  onChange={(event) => {
+                    const next = [...newChildren];
+                    next[index] = event.target.value;
+                    setNewChildren(next);
+                  }}
+                  placeholder="Child title"
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setNewChildren((current) => current.filter((_, idx) => idx !== index))}
+                >
+                  Remove
+                </Button>
+              </div>
+            ))}
+          </div>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => setNewChildren((current) => [...current, ""])}
+          >
+            + Add Another Child
+          </Button>
+        </div>
+
+        <div className="flex flex-wrap gap-3 pt-2">
+          <Button type="submit">Save Card</Button>
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+          {editing && card && onDelete && (
+            <Button type="button" variant="destructive" onClick={() => onDelete(card.id)}>
+              Delete Card
+            </Button>
+          )}
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/figma/src/views/CardListView.tsx
+++ b/figma/src/views/CardListView.tsx
@@ -1,0 +1,167 @@
+import { CardID, StoreShape } from "../lib/types";
+import { InfoCard } from "../components/InfoCard";
+import { bodyPreview, formatDate } from "../lib/format";
+import { Button } from "../components/ui/button";
+import { MoreHorizontal } from "lucide-react";
+import { useMemo, useCallback } from "react";
+import { SimpleMenu } from "../components/SimpleMenu";
+
+export type SortOption = "alpha" | "updated" | "created";
+
+interface CardListViewProps {
+  store: StoreShape;
+  parentId: CardID | null;
+  sort: SortOption;
+  onSortChange: (option: SortOption) => void;
+  onOpenCard: (cardId: CardID) => void;
+  onViewChildren: (cardId: CardID) => void;
+  onAddCardHere: (parentId: CardID | null) => void;
+  onAddChild: (cardId: CardID) => void;
+  onExport: (cardId: CardID, exportType: "card-json" | "card-txt" | "subtree-json" | "subtree-txt") => void;
+  onCardRender: (cardId: CardID, element: HTMLElement | null) => void;
+}
+
+export function CardListView({
+  store,
+  parentId,
+  sort,
+  onSortChange,
+  onOpenCard,
+  onViewChildren,
+  onAddCardHere,
+  onAddChild,
+  onExport,
+  onCardRender
+}: CardListViewProps) {
+  const cards = useMemo(() => {
+    if (!parentId) {
+      return store.rootOrder.map((id) => store.cards[id]).filter(Boolean);
+    }
+    const parent = store.cards[parentId];
+    if (!parent) return [];
+    return parent.children.map((id) => store.cards[id]).filter(Boolean);
+  }, [store, parentId]);
+
+  const sortedCards = useMemo(() => {
+    const list = [...cards];
+    if (sort === "alpha") {
+      list.sort((a, b) => (a.title || "").toLowerCase().localeCompare((b.title || "").toLowerCase()));
+    } else if (sort === "updated") {
+      list.sort((a, b) => (b.updatedAt || 0) - (a.updatedAt || 0));
+    } else if (sort === "created") {
+      list.sort((a, b) => (b.createdAt || 0) - (a.createdAt || 0));
+    }
+    return list;
+  }, [cards, sort]);
+
+  const heading = parentId ? store.cards[parentId]?.title || "Children" : "Top Level Cards";
+
+  const createRef = useCallback(
+    (cardId: CardID) => (element: HTMLElement | null) => {
+      onCardRender(cardId, element);
+    },
+    [onCardRender]
+  );
+
+  return (
+    <section className="space-y-12">
+      <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+        <div className="space-y-3">
+          <h2 className="text-5xl font-semibold tracking-tight text-foreground">{heading}</h2>
+          {parentId && (
+            <p className="max-w-xl text-base text-muted-foreground">
+              Showing {sortedCards.length} cards nested under this topic.
+            </p>
+          )}
+        </div>
+        <div className="space-y-2 text-sm text-muted-foreground">
+          <span className="uppercase tracking-[0.3em]">Sort</span>
+          <select
+            className="w-full rounded-full border border-transparent bg-muted/25 px-5 py-3 text-sm text-foreground transition focus:border-foreground/20 focus:bg-muted/35 focus:outline-none md:w-auto"
+            value={sort}
+            onChange={(event) => onSortChange(event.target.value as SortOption)}
+          >
+            <option value="alpha">Alphabetical</option>
+            <option value="updated">Recently Updated</option>
+            <option value="created">Recently Created</option>
+          </select>
+        </div>
+      </div>
+
+      <div className="space-y-8">
+        {sortedCards.map((card) => (
+          <InfoCard
+            key={card!.id}
+            title={card!.title}
+            preview={bodyPreview(card!.body)}
+            subtitle={`Updated ${formatDate(card!.updatedAt)}`}
+            childrenCount={card!.children.length}
+            onClick={() => onOpenCard(card!.id)}
+            ref={createRef(card!.id)}
+            actions={
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  variant="primary"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onOpenCard(card!.id);
+                  }}
+                >
+                  Open Card
+                </Button>
+                <Button
+                  variant="secondary"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onAddChild(card!.id);
+                  }}
+                >
+                  + Add Child
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onViewChildren(card!.id);
+                  }}
+                >
+                  View Children
+                </Button>
+                <div
+                  onClick={(event) => event.stopPropagation()}
+                  onKeyDown={(event) => event.stopPropagation()}
+                  role="presentation"
+                >
+                  <SimpleMenu
+                    triggerIcon={<MoreHorizontal className="h-4 w-4" />}
+                    triggerLabel="Card export menu"
+                    triggerClassName="h-10 w-10 rounded-full bg-foreground/10 text-foreground hover:bg-foreground/20"
+                    items={[
+                      { label: "Download Card (JSON)", onSelect: () => onExport(card!.id, "card-json") },
+                      { label: "Download Card (TXT)", onSelect: () => onExport(card!.id, "card-txt") },
+                      { label: "Download Card + Children (JSON)", onSelect: () => onExport(card!.id, "subtree-json") },
+                      { label: "Download Card + Children (TXT)", onSelect: () => onExport(card!.id, "subtree-txt") }
+                    ]}
+                    menuClassName="w-72"
+                  />
+                </div>
+              </div>
+            }
+          />
+        ))}
+
+        {sortedCards.length === 0 && (
+          <div className="rounded-[32px] bg-muted/20 px-10 py-16 text-center text-muted-foreground">
+            No cards yet. Start by creating one below.
+          </div>
+        )}
+      </div>
+
+      <div className="pt-6">
+        <Button onClick={() => onAddCardHere(parentId)} size="lg" variant="secondary">
+          + Add Card Here
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/figma/src/views/SearchResultsView.tsx
+++ b/figma/src/views/SearchResultsView.tsx
@@ -1,0 +1,41 @@
+import { Card, CardID } from "../lib/types";
+import { InfoCard } from "../components/InfoCard";
+import { bodyPreview, formatDate } from "../lib/format";
+
+interface SearchResultsViewProps {
+  query: string;
+  results: Card[];
+  onOpenCard: (cardId: CardID) => void;
+  onCardRender: (cardId: CardID, element: HTMLElement | null) => void;
+}
+
+export function SearchResultsView({ query, results, onOpenCard, onCardRender }: SearchResultsViewProps) {
+  return (
+    <section className="space-y-8">
+      <header>
+        <h2 className="text-foreground text-4xl font-semibold">Search</h2>
+        <p className="text-muted-foreground mt-2">Results for “{query}” ({results.length})</p>
+      </header>
+
+      {results.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-border px-6 py-12 text-center text-muted-foreground">
+          No cards matched your search.
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {results.map((card) => (
+            <InfoCard
+              key={card.id}
+              title={card.title}
+              preview={bodyPreview(card.body)}
+              subtitle={`Updated ${formatDate(card.updatedAt)}`}
+              childrenCount={card.children.length}
+              onClick={() => onOpenCard(card.id)}
+              ref={(element) => onCardRender(card.id, element)}
+            />
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/figma/vite.config.ts
+++ b/figma/vite.config.ts
@@ -1,0 +1,22 @@
+
+  import { defineConfig } from 'vite';
+  import react from '@vitejs/plugin-react-swc';
+  import path from 'path';
+
+  export default defineConfig({
+    plugins: [react()],
+    resolve: {
+      extensions: ['.js', '.jsx', '.ts', '.tsx', '.json'],
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
+    },
+    build: {
+      target: 'esnext',
+      outDir: 'build',
+    },
+    server: {
+      port: 3000,
+      open: true,
+    },
+  });


### PR DESCRIPTION
## Summary
- replace the Radix/shadcn primitives with bespoke button, input, textarea, and modal helpers while keeping import, export, and mod management flows intact
- refresh the header hero, action surface, and card list/detail/form views to lean into the Figma white-space aesthetic and restore quick access to every action
- trim unused dependencies and aliases from the Vite client and update attribution notes to reflect the new in-house primitives

## Testing
- npm install *(fails: registry denies @types/node due to 403 policy)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691248b70e8483299e9d75b30ae48603)