### PR TITLE
Fix sample extensions to match supported hooks

### DIFF
--- a/docs/sample-extensions.md
+++ b/docs/sample-extensions.md
@@ -1,0 +1,40 @@
+# Sample Extension Concepts
+
+The examples below provide two concepts per extension type, showing a simple starter idea and a more advanced option that stretches the category. Align each concept with the extension rules in `cardspoke_spec_v1.md` (e.g., Themes stay cosmetic, Mods can alter core logic, Kits bundle Themes/Patches only, Expansions include at least one Plugin or Mod).
+
+## Themes
+- **Minimalist Monochrome (simple):** A grayscale palette with high-contrast text, slim borders, and subtle elevation; swaps only CSS variables and typography scales to stay cosmetic.
+- **Aurora Workspace (complex):** Dynamic accent gradients that shift based on time-of-day, per-lane background treatments, card density toggles, and contextual iconography for tags—all implemented through themable tokens without touching logic.
+
+## Plugins
+- **Quick Capture Dock (simple):** Adds a collapsible bottom dock for rapid card entry with preset templates and keyboard shortcuts; no changes to existing logic.
+- **Insight Overlay (complex):** Injects a side panel that surfaces card analytics (cycle time, tag frequency, sentiment snippets) with drill-down filters and export-to-CSV, powered by read-only data queries.
+
+## Mods
+- **Strict WIP Guard (simple):** Enforces per-lane work-in-progress limits by blocking moves that would exceed thresholds and showing inline rationale.
+- **Adaptive Flow Orchestrator (complex):** Rewrites routing rules so cards auto-advance based on rulesets (e.g., SLA, priority, dependency status), injects required checkpoints, and rewires keyboard shortcuts to match the new flow.
+
+## Kits
+- **Focus Kit (simple):** Bundle that combines the Minimalist Monochrome Theme with a Patch that disables non-critical notifications for distraction-free sessions.
+- **Product Discovery Kit (complex):** Bundles the Aurora Workspace Theme with a Patch that adds discovery-specific card fields, custom filters, and curated dashboards; excludes any Plugins or Mods to remain a Kit.
+
+## Expansions
+- **Customer Success Expansion (simple):** Includes a Success Desk Plugin (SLA timers, renewal watchlist) plus a WIP Guard Mod variant tuned for account managers.
+- **AI Research Expansion (complex):** Ships an Insight Overlay Plugin enhanced with AI summarization, a Mod that adds experiment workflow states, domain-specific Themes for readability, and optional integrations to external vector stores.
+
+## Downloadable Samples
+Concrete sample files that match the concepts above live in `extensions/samples/`:
+
+- **Themes:** `extensions/samples/themes/minimalist-monochrome.theme.json`, `extensions/samples/themes/aurora-workspace.theme.json`
+- **Plugins:** `extensions/samples/plugins/quick-capture-dock.plugin.js`, `extensions/samples/plugins/insight-overlay.plugin.js`
+- **Mods:** `extensions/samples/mods/strict-wip-guard.mod.js`, `extensions/samples/mods/adaptive-flow-orchestrator.mod.js`
+- **Kits:** `extensions/samples/kits/focus-kit.kit.json`, `extensions/samples/kits/product-discovery.kit.json`
+- **Expansions:** `extensions/samples/expansions/customer-success.expansion.json`, `extensions/samples/expansions/ai-research.expansion.json`
+
+### Why the earlier samples failed
+
+- The live extension runtime only exposes the hooks listed in `CardSpoke_MODS.VALID_HOOKS` inside `www/app.js` (`onAppInit`, `onCardSave`, `onCardDelete`, `onCardRender`, `onNavigate`, `onSearch`, `onThemeChange`, `onTypographyChange`, `onHighContrastChange`, `onExport`, `onImport`, `onEnable`, `onDisable`, `onUninstall`).
+- The public APIs available to mods come from `window.CardSpoke.utils` and the `ctx.api` object created in `CardSpoke_MODS.buildContext`—there is **no** `ctx.events`, `ctx.analytics`, `ctx.board`, or `ctx.utils.registerShortcut` helper today.
+- Earlier sample files called unsupported hooks and APIs, so they never registered cleanly. The updated samples now stick to the available hooks and the documented `CardSpoke.utils`/`ctx.api` methods (e.g., `createCard`, `searchCards`, `listCards`, `updateCard`, `getNavState`, `showToast`).
+
+If you add new capabilities to the runtime, update this doc and the sample files so they remain runnable with the shipped APIs.

--- a/extensions/samples/expansions/ai-research.expansion.json
+++ b/extensions/samples/expansions/ai-research.expansion.json
@@ -1,0 +1,38 @@
+{
+  "meta": {
+    "id": "expansion-ai-research",
+    "name": "AI Research Expansion",
+    "type": "Expansion",
+    "version": "1.2.0",
+    "description": "Insight overlay with AI summaries, experimental workflow mod, domain themes, and vector store integrations."
+  },
+  "includes": {
+    "plugins": [
+      {
+        "id": "plugin-insight-overlay-ai",
+        "extends": "plugin-insight-overlay",
+        "overrides": {
+          "meta": { "version": "1.2.0" },
+          "features": {
+            "summarization": true,
+            "vectorSearch": true
+          }
+        }
+      }
+    ],
+    "mods": [
+      "mod-adaptive-flow-orchestrator"
+    ],
+    "themes": [
+      "theme-aurora-workspace"
+    ],
+    "integrations": [
+      {
+        "id": "vectorstore-hub",
+        "provider": "hypothetical-vector-hub",
+        "capabilities": ["embed", "search"],
+        "env": ["VECTOR_API_KEY"]
+      }
+    ]
+  }
+}

--- a/extensions/samples/expansions/customer-success.expansion.json
+++ b/extensions/samples/expansions/customer-success.expansion.json
@@ -1,0 +1,26 @@
+{
+  "meta": {
+    "id": "expansion-customer-success",
+    "name": "Customer Success Expansion",
+    "type": "Expansion",
+    "version": "1.0.0",
+    "description": "Success desk plugin plus WIP guard tuned for account managers."
+  },
+  "includes": {
+    "plugins": ["plugin-quick-capture-dock"],
+    "mods": [
+      {
+        "id": "mod-wip-accounts",
+        "extends": "mod-strict-wip-guard",
+        "overrides": {
+          "limits": {
+            "todo": 6,
+            "doing": 4,
+            "review": 5
+          }
+        }
+      }
+    ],
+    "themes": ["theme-minimalist-monochrome"]
+  }
+}

--- a/extensions/samples/kits/focus-kit.kit.json
+++ b/extensions/samples/kits/focus-kit.kit.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "id": "kit-focus",
+    "name": "Focus Kit",
+    "type": "Kit",
+    "version": "1.0.0",
+    "description": "Bundle that pairs Minimalist Monochrome theme with notification-slimming patches."
+  },
+  "includes": {
+    "themes": ["theme-minimalist-monochrome"],
+    "patches": [
+      {
+        "id": "patch-quiet-mode",
+        "description": "Disable non-critical notifications and badge animations for deep-work sessions.",
+        "changes": {
+          "notifications": {
+            "mute": true,
+            "allowList": ["mentions", "directAssignments"]
+          },
+          "badges": {
+            "animate": false
+          }
+        }
+      }
+    ]
+  }
+}

--- a/extensions/samples/kits/product-discovery.kit.json
+++ b/extensions/samples/kits/product-discovery.kit.json
@@ -1,0 +1,45 @@
+{
+  "meta": {
+    "id": "kit-product-discovery",
+    "name": "Product Discovery Kit",
+    "type": "Kit",
+    "version": "1.1.0",
+    "description": "Aurora theme plus discovery-specific fields, filters, and curated dashboard layout (no plugins or mods)."
+  },
+  "includes": {
+    "themes": ["theme-aurora-workspace"],
+    "patches": [
+      {
+        "id": "patch-discovery-fields",
+        "description": "Adds discovery fields and card templates.",
+        "changes": {
+          "cardFields": [
+            { "key": "problem", "label": "Problem Statement", "type": "text" },
+            { "key": "signal", "label": "Signal Source", "type": "enum", "options": ["analytics", "research", "support"] },
+            { "key": "confidence", "label": "Confidence", "type": "scale", "min": 1, "max": 5 }
+          ]
+        }
+      },
+      {
+        "id": "patch-discovery-views",
+        "description": "Curated filters and dashboard widgets for discovery flow.",
+        "changes": {
+          "filters": [
+            { "id": "experiments", "query": "tag:experiment" },
+            { "id": "risks", "query": "tag:risk" },
+            { "id": "customer-voice", "query": "tag:feedback" }
+          ],
+          "dashboards": [
+            {
+              "id": "learning-dashboard",
+              "widgets": [
+                { "type": "count", "query": "tag:experiment", "label": "Active Experiments" },
+                { "type": "chart", "query": "tag:risk", "label": "Top Risks" }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/extensions/samples/mods/adaptive-flow-orchestrator.mod.js
+++ b/extensions/samples/mods/adaptive-flow-orchestrator.mod.js
@@ -1,0 +1,65 @@
+(function() {
+  'use strict';
+
+  const Orchestrator = {
+    meta: {
+      id: 'mod-adaptive-flow-orchestrator',
+      name: 'Adaptive Flow Orchestrator',
+      type: 'Mod',
+      version: '1.2.1',
+      description: 'Auto-adjusts tags and reminders based on simple rules and provides keyboard navigation without custom APIs.'
+    },
+
+    rules: [
+      { match: (card) => (card.tags || []).includes('urgent'), apply: (ctx, card) => this.ensureTag(ctx, card, 'doing') },
+      { match: (card) => (card.tags || []).includes('blocked'), apply: (ctx, card) => this.ensureTag(ctx, card, 'review') },
+      { match: (card) => (card.body || '').toLowerCase().includes('experiment'), apply: (ctx, card) => this.ensureTag(ctx, card, 'experiment') }
+    ],
+
+    shortcutListener: null,
+
+    onAppInit(ctx) {
+      this.bindShortcuts(ctx);
+    },
+
+    onCardSave(ctx, card) {
+      this.rules.forEach((rule) => {
+        if (rule.match(card)) {
+          rule.apply(ctx, card);
+        }
+      });
+    },
+
+    onDisable() {
+      if (this.shortcutListener) {
+        document.removeEventListener('keydown', this.shortcutListener);
+        this.shortcutListener = null;
+      }
+    },
+
+    ensureTag(ctx, card, tag) {
+      const tags = Array.from(new Set([...(card.tags || []), tag]));
+      ctx.api.updateCard(card.id, { tags });
+      ctx.utils.showToast(`Marked card ${card.title || card.id} for ${tag}`, 'info');
+    },
+
+    bindShortcuts(ctx) {
+      if (this.shortcutListener) return;
+      this.shortcutListener = (event) => {
+        if (!event.ctrlKey || !event.shiftKey) return;
+        const key = event.key.toLowerCase();
+        const targetTag = key === 'd' ? 'doing' : key === 'r' ? 'review' : key === 'b' ? 'blocked' : null;
+        if (!targetTag) return;
+        event.preventDefault();
+        const currentCardId = ctx.api.getNavState().cardId;
+        if (!currentCardId) return;
+        const card = ctx.api.getCard(currentCardId);
+        if (!card) return;
+        this.ensureTag(ctx, card, targetTag);
+      };
+      document.addEventListener('keydown', this.shortcutListener);
+    }
+  };
+
+  CardSpoke_MODS.register(Orchestrator.meta.id, Orchestrator);
+})();

--- a/extensions/samples/mods/strict-wip-guard.mod.js
+++ b/extensions/samples/mods/strict-wip-guard.mod.js
@@ -1,0 +1,44 @@
+(function() {
+  'use strict';
+
+  // Simple WIP guard that enforces limits based on lane tags on save.
+  // Lanes are derived from tags: todo, doing, review, done.
+  const WipGuard = {
+    meta: {
+      id: 'mod-strict-wip-guard',
+      name: 'Strict WIP Guard',
+      type: 'Mod',
+      version: '1.1.0',
+      description: 'Enforces per-lane limits (todo/doing/review/done) by reverting saves that exceed thresholds.'
+    },
+
+    limits: {
+      todo: 8,
+      doing: 4,
+      review: 4,
+      done: 999
+    },
+
+    onCardSave(ctx, card, info) {
+      const lane = this.getLane(card.tags);
+      if (!lane) return;
+      const limit = this.limits[lane];
+      if (!limit) return;
+
+      const peers = ctx.api.listCards().filter((c) => this.getLane(c.tags) === lane);
+      if (peers.length > limit) {
+        ctx.logger.warn(`Lane ${lane} limit reached (${limit}). Reverting change for card ${card.id}.`);
+        ctx.utils.showToast(`Cannot place card in ${lane}. Lane is at capacity (${limit}).`, 'error');
+        const previousTags = info?.previousData?.tags || (card.tags || []).filter((t) => t !== lane);
+        ctx.api.updateCard(card.id, { tags: previousTags });
+      }
+    },
+
+    getLane(tags = []) {
+      const laneTags = ['todo', 'doing', 'review', 'done'];
+      return laneTags.find((tag) => tags.includes(tag));
+    }
+  };
+
+  CardSpoke_MODS.register(WipGuard.meta.id, WipGuard);
+})();

--- a/extensions/samples/plugins/insight-overlay.plugin.js
+++ b/extensions/samples/plugins/insight-overlay.plugin.js
@@ -1,0 +1,166 @@
+(function() {
+  'use strict';
+
+  const Overlay = {
+    meta: {
+      id: 'plugin-insight-overlay',
+      name: 'Insight Overlay',
+      type: 'Plugin',
+      version: '1.1.1',
+      description: 'Side panel with analytics, filters, and CSV export using supported CardSpoke mod hooks and APIs.'
+    },
+
+    panel: null,
+    lastRenderedTag: '',
+
+    onAppInit(ctx) {
+      this.renderPanel(ctx);
+    },
+
+    onCardSave(ctx) {
+      // Keep analytics in sync without relying on custom events
+      this.refresh(ctx);
+    },
+
+    onDisable() {
+      if (this.panel && this.panel.parentNode) {
+        this.panel.parentNode.removeChild(this.panel);
+      }
+      this.panel = null;
+    },
+
+    renderPanel(ctx) {
+      if (this.panel) return;
+      const panel = document.createElement('aside');
+      panel.id = 'insight-overlay';
+      panel.style.cssText = [
+        'position: fixed',
+        'top: 0',
+        'right: 0',
+        'height: 100vh',
+        'width: 360px',
+        'background: var(--bg-panel, #0f1523)',
+        'border-left: 1px solid var(--border, #1f2a3d)',
+        'box-shadow: -12px 0 30px rgba(0,0,0,0.35)',
+        'padding: 16px',
+        'overflow-y: auto',
+        'transform: translateX(0)',
+        'transition: transform 120ms ease',
+        'z-index: 9998'
+      ].join(';');
+
+      panel.innerHTML = `
+        <header style="display:flex;align-items:center;gap:8px;">
+          <strong style="flex:1">Insights</strong>
+          <button data-overlay-close aria-label="Close">Close</button>
+        </header>
+        <section id="insight-summary" style="margin-top:12px;">
+          Loading analytics...
+        </section>
+        <section style="margin-top:16px;display:flex;gap:8px;">
+          <input data-filter-tag placeholder="Filter by tag" style="flex:1" />
+          <button data-filter-apply class="btn">Apply</button>
+        </section>
+        <section style="margin-top:12px;display:flex;gap:8px;">
+          <button data-export class="btn btn-secondary">Export CSV</button>
+          <button data-refresh class="btn btn-secondary">Refresh</button>
+        </section>
+      `;
+
+      panel.querySelector('[data-overlay-close]').onclick = () => this.hidePanel();
+      panel.querySelector('[data-filter-apply]').onclick = () => this.applyFilter(ctx);
+      panel.querySelector('[data-refresh]').onclick = () => this.refresh(ctx);
+      panel.querySelector('[data-export]').onclick = () => this.exportCsv(ctx);
+
+      this.panel = panel;
+      document.body.appendChild(panel);
+      this.refresh(ctx);
+    },
+
+    refresh(ctx) {
+      if (!this.panel) return;
+      const { totalCards, avgCycleTime, topTags } = this.computeSnapshot(ctx);
+      const summary = this.panel.querySelector('#insight-summary');
+      const rows = [
+        `<p><strong>Cards:</strong> ${totalCards}</p>`,
+        `<p><strong>Avg Cycle Time:</strong> ${avgCycleTime ?? 'n/a'}</p>`,
+        `<p><strong>Tags:</strong> ${topTags.map((t) => `#${t.tag} (${t.count})`).join(', ') || 'none'}</p>`
+      ];
+      summary.innerHTML = rows.join('');
+    },
+
+    computeSnapshot(ctx) {
+      const cards = ctx.api.listCards();
+      const tagCounts = {};
+      let cycleTimeTotal = 0;
+      let cycleTimeCount = 0;
+
+      cards.forEach((card) => {
+        (card.tags || []).forEach((tag) => {
+          tagCounts[tag] = (tagCounts[tag] || 0) + 1;
+        });
+
+        if (card.createdAt && card.updatedAt && card.updatedAt > card.createdAt) {
+          cycleTimeTotal += card.updatedAt - card.createdAt;
+          cycleTimeCount += 1;
+        }
+      });
+
+      const topTags = Object.entries(tagCounts)
+        .map(([tag, count]) => ({ tag, count }))
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 5);
+
+      const avgCycleTime = cycleTimeCount ? `${Math.round((cycleTimeTotal / cycleTimeCount) / (1000 * 60 * 60))}h` : null;
+
+      return {
+        totalCards: cards.length,
+        avgCycleTime,
+        topTags
+      };
+    },
+
+    togglePanel() {
+      if (!this.panel) return;
+      const hidden = this.panel.style.transform.includes('translateX(100%)');
+      this.panel.style.transform = hidden ? 'translateX(0)' : 'translateX(100%)';
+    },
+
+    hidePanel() {
+      if (this.panel) {
+        this.panel.style.transform = 'translateX(100%)';
+      }
+    },
+
+    applyFilter(ctx) {
+      if (!this.panel) return;
+      const tag = this.panel.querySelector('[data-filter-tag]').value.trim();
+      if (!tag) return this.refresh(ctx);
+      this.lastRenderedTag = tag;
+      const cards = ctx.api.listCards().filter((card) => (card.tags || []).includes(tag));
+      const summary = this.panel.querySelector('#insight-summary');
+      summary.innerHTML = `<p><strong>${cards.length}</strong> cards with #${tag}</p>`;
+    },
+
+    exportCsv(ctx) {
+      const snapshot = this.computeSnapshot(ctx);
+      const rows = [
+        ['metric', 'value'],
+        ['total_cards', snapshot.totalCards],
+        ['avg_cycle_time_hours', snapshot.avgCycleTime || 'n/a'],
+        ...snapshot.topTags.map((t) => [`tag_${t.tag}`, t.count])
+      ];
+      const csv = rows.map((r) => r.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(',')).join('\n');
+      const blob = new Blob([csv], { type: 'text/csv' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'insights.csv';
+      link.click();
+      URL.revokeObjectURL(url);
+      ctx.utils.showToast('Exported insights to CSV', 'success');
+    }
+  };
+
+  CardSpoke_MODS.register(Overlay.meta.id, Overlay);
+})();

--- a/extensions/samples/plugins/quick-capture-dock.plugin.js
+++ b/extensions/samples/plugins/quick-capture-dock.plugin.js
@@ -1,0 +1,111 @@
+(function() {
+  'use strict';
+
+  const Dock = {
+    meta: {
+      id: 'plugin-quick-capture-dock',
+      name: 'Quick Capture Dock',
+      type: 'Plugin',
+      version: '1.0.1',
+      description: 'Collapsible bottom dock for rapid card entry with presets and shortcuts (uses supported CardSpoke utils only).'
+    },
+
+    dockEl: null,
+    shortcutListener: null,
+
+    onAppInit(ctx) {
+      this.renderDock(ctx);
+      this.bindShortcut(ctx);
+    },
+
+    onDisable() {
+      if (this.shortcutListener) {
+        document.removeEventListener('keydown', this.shortcutListener);
+        this.shortcutListener = null;
+      }
+      if (this.dockEl && this.dockEl.parentNode) {
+        this.dockEl.parentNode.removeChild(this.dockEl);
+      }
+      this.dockEl = null;
+    },
+
+    renderDock(ctx) {
+      if (this.dockEl) return;
+      const dock = document.createElement('section');
+      dock.id = 'quick-capture-dock';
+      dock.style.cssText = [
+        'position: fixed',
+        'left: 50%',
+        'bottom: 0',
+        'transform: translateX(-50%)',
+        'width: min(960px, 96vw)',
+        'background: var(--bg-panel, #16181d)',
+        'border: 1px solid var(--border, #2c2f36)',
+        'border-radius: 14px 14px 0 0',
+        'box-shadow: 0 -10px 30px rgba(0,0,0,0.35)',
+        'padding: 12px 16px',
+        'z-index: 9999'
+      ].join(';');
+
+      dock.innerHTML = `
+        <header style="display:flex;align-items:center;gap:8px;">
+          <strong style="flex:1">Quick Capture</strong>
+          <button aria-label="Close" data-dock-toggle>&#x2715;</button>
+        </header>
+        <div style="display:flex;gap:8px;margin-top:8px;">
+          <input type="text" data-dock-title placeholder="Task title" style="flex:1" />
+          <select data-dock-template>
+            <option value="blank">Blank</option>
+            <option value="bug">Bug</option>
+            <option value="idea">Idea</option>
+          </select>
+          <button class="btn btn-primary" data-dock-submit>Capture</button>
+        </div>
+      `;
+
+      dock.querySelector('[data-dock-toggle]').onclick = () => this.toggleDock();
+      dock.querySelector('[data-dock-submit]').onclick = () => this.createCard(ctx, dock);
+      this.dockEl = dock;
+      document.body.appendChild(dock);
+    },
+
+    async createCard(ctx, dock) {
+      const title = dock.querySelector('[data-dock-title]').value || 'New card';
+      const template = dock.querySelector('[data-dock-template]').value;
+      const templates = {
+        bug: { tags: ['bug'], body: 'Describe the issue, steps, and expected behavior.' },
+        idea: { tags: ['idea'], body: 'What is the idea? Who benefits? Expected impact?' },
+        blank: { tags: [], body: '' }
+      };
+
+      const payload = Object.assign({ title }, templates[template]);
+      const result = await ctx.utils.createCard(payload);
+      ctx.utils.showToast('Captured card to backlog', 'success');
+      dock.querySelector('[data-dock-title]').value = '';
+      ctx.logger.info('Captured card', result.id);
+    },
+
+    bindShortcut(ctx) {
+      if (this.shortcutListener) return;
+      this.shortcutListener = (event) => {
+        const key = event.key.toLowerCase();
+        if (event.ctrlKey && event.shiftKey && key === 'c') {
+          event.preventDefault();
+          this.toggleDock(ctx);
+        }
+      };
+      document.addEventListener('keydown', this.shortcutListener);
+    },
+
+    toggleDock(ctx) {
+      if (!this.dockEl) {
+        this.renderDock(ctx);
+        return;
+      }
+      const hidden = this.dockEl.style.display === 'none';
+      this.dockEl.style.display = hidden ? 'block' : 'none';
+    }
+  };
+
+  CardSpoke_MODS.register(Dock.meta.id, Dock);
+})();

--- a/extensions/samples/themes/aurora-workspace.theme.json
+++ b/extensions/samples/themes/aurora-workspace.theme.json
@@ -1,0 +1,71 @@
+{
+  "meta": {
+    "id": "theme-aurora-workspace",
+    "name": "Aurora Workspace",
+    "type": "Theme",
+    "version": "1.1.0",
+    "description": "Dynamic gradients, density toggles, and contextual tag iconography for information-dense boards."
+  },
+  "behaviors": {
+    "timeAwareAccents": {
+      "dawn": "linear-gradient(135deg, #fcb045 0%, #fd1d1d 100%)",
+      "day": "linear-gradient(135deg, #30cfd0 0%, #330867 100%)",
+      "dusk": "linear-gradient(135deg, #1a2a6c 0%, #b21f1f 50%, #fdbb2d 100%)",
+      "night": "linear-gradient(135deg, #0f2027 0%, #203a43 50%, #2c5364 100%)"
+    },
+    "densityProfiles": {
+      "cozy": {
+        "cardPadding": 16,
+        "cardGap": 14,
+        "shadow": "0 10px 34px rgba(0, 0, 0, 0.22)"
+      },
+      "compact": {
+        "cardPadding": 10,
+        "cardGap": 8,
+        "shadow": "0 6px 20px rgba(0, 0, 0, 0.18)"
+      }
+    },
+    "tagIcons": {
+      "risk": "⚠️",
+      "vip": "⭐",
+      "experiment": "🧪",
+      "blocked": "⛔"
+    }
+  },
+  "tokens": {
+    "colors": {
+      "background": "#0b1021",
+      "surface": "rgba(15, 25, 50, 0.65)",
+      "muted": "rgba(255, 255, 255, 0.08)",
+      "border": "rgba(255, 255, 255, 0.12)",
+      "text": "#f7fbff",
+      "textSubtle": "#d7e3f4",
+      "accent": "#7cf3ff",
+      "accentMuted": "#4db8ff"
+    },
+    "typography": {
+      "fontFamily": "'Manrope', 'Inter', system-ui, sans-serif",
+      "titleWeight": 800,
+      "bodyWeight": 500,
+      "letterSpacing": 0.005
+    },
+    "shadows": {
+      "card": "0 12px 40px rgba(10, 12, 36, 0.55)",
+      "popover": "0 20px 60px rgba(0, 0, 0, 0.45)"
+    },
+    "radii": {
+      "card": 14,
+      "panel": 18
+    }
+  },
+  "cssVariables": {
+    "--bg": "#0b1021",
+    "--bg-panel": "rgba(15, 25, 50, 0.65)",
+    "--bg-muted": "rgba(255, 255, 255, 0.08)",
+    "--border": "rgba(255, 255, 255, 0.12)",
+    "--text": "#f7fbff",
+    "--text-subtle": "#d7e3f4",
+    "--accent": "#7cf3ff",
+    "--accent-muted": "#4db8ff"
+  }
+}

--- a/extensions/samples/themes/minimalist-monochrome.theme.json
+++ b/extensions/samples/themes/minimalist-monochrome.theme.json
@@ -1,0 +1,45 @@
+{
+  "meta": {
+    "id": "theme-minimalist-monochrome",
+    "name": "Minimalist Monochrome",
+    "type": "Theme",
+    "version": "1.0.0",
+    "description": "High-contrast grayscale palette with crisp typography and minimal chrome."
+  },
+  "tokens": {
+    "colors": {
+      "background": "#0f0f10",
+      "surface": "#191a1c",
+      "muted": "#26282b",
+      "border": "#3a3d42",
+      "text": "#f5f7fa",
+      "textSubtle": "#c7ccd4",
+      "accent": "#8ab4f8",
+      "accentMuted": "#6079a8"
+    },
+    "typography": {
+      "fontFamily": "'Inter', 'SF Pro Display', system-ui, sans-serif",
+      "titleWeight": 700,
+      "bodyWeight": 400,
+      "letterSpacing": 0.01
+    },
+    "shadows": {
+      "card": "0 4px 14px rgba(0, 0, 0, 0.3)",
+      "popover": "0 8px 30px rgba(0, 0, 0, 0.35)"
+    },
+    "radii": {
+      "card": 8,
+      "panel": 12
+    }
+  },
+  "cssVariables": {
+    "--bg": "#0f0f10",
+    "--bg-panel": "#191a1c",
+    "--bg-muted": "#26282b",
+    "--border": "#3a3d42",
+    "--text": "#f5f7fa",
+    "--text-subtle": "#c7ccd4",
+    "--accent": "#8ab4f8",
+    "--accent-muted": "#6079a8"
+  }
+}


### PR DESCRIPTION
## Summary
- rewrite sample plugin and mod files to use only the supported CardSpoke hooks and `CardSpoke.utils`/`ctx.api` methods so they register successfully
- document the currently available hooks and APIs in the sample extensions guide and note why the earlier samples failed

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692cac90c67483299aa067971ec751d7)