### PR TITLE
Add comprehensive documentation set

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1,0 +1,61 @@
+# Developer Guide (Core App)
+
+This guide explains how to work on the CardSpoke core app, run tests, and align with the project’s lightweight, extension-first philosophy.
+
+## Architecture Overview
+- **Ultra-light core:** Keep the main bundle lean. Prefer Extensions for new features to avoid permanent bloat.
+- **Card model:** UI presents hierarchical, tiered cards for navigating knowledge. Keep data structures minimal and schema-forward.
+- **Extension boundary:** Core should expose hooks and configuration points; invasive changes belong to Mods or Expansions.
+- **Local-first:** Default storage is LocalStorage/IndexedDB; avoid adding network dependencies without opt-in controls.
+
+## Repository Layout
+- `www/` – Prebuilt client bundle consumed by Capacitor. Update via the build pipeline before syncing.
+- `tests/` – uvu test suites.
+- `types/` – Shared types.
+- `test-extension-improvements.js` – Extension behavior checks.
+- `capacitor.config.json` – Platform configuration for Capacitor.
+
+## Development Workflow
+1. Install dependencies: `npm install` (Node 18+ recommended).
+2. Make changes in the source that feeds `www/` (if editing the web bundle) and rebuild:
+   ```bash
+   npm run build
+   ```
+3. Run tests:
+   ```bash
+   npm test
+   ```
+4. For mobile validation, sync and open the native shells (see [Capacitor Guide](./README.CAPACITOR.md)).
+
+## Coding Conventions
+- Keep the code ultra-light; avoid unnecessary dependencies and heavy abstractions.
+- Do not silently collect or transmit user data; any remote integration must be explicit and opt-in.
+- Prefer pure, deterministic functions; make side effects explicit.
+- Add hooks/events instead of baking in narrow features; Extensions should be able to compose behavior.
+- Avoid try/catch around imports; let module resolution fail loudly.
+- Maintain clear separation between core logic and angled content (Extensions).
+
+## Testing
+- Use `uvu` (`npm test`) for fast unit/behavioral coverage.
+- Co-locate tests under `tests/` with descriptive filenames.
+- For Extension-specific tests, include metadata samples and compatibility toggles.
+- When adding schema changes, cover migration and fallback behavior.
+
+## Accessibility & UX
+- Keep UI fast and uncluttered; avoid over-nesting of controls.
+- Ensure keyboard navigation and readable contrast in default themes; document any deviations in Theme Extensions.
+
+## Performance
+- Keep bundles small; prune dead code and unused dependencies.
+- Prefer lazy loading for heavy assets injected by Extensions.
+- Use the “Bake Mode” concept (merging Extensions) cautiously to avoid shipping incompatible combinations.
+
+## Release Hygiene
+- Update changelogs and metadata for any core update.
+- Document schema version changes and migrations in [Schema & Migration Docs](./SCHEMA.md).
+- Clearly mark whether a change is **official** (core) or **angled** (Extension).
+
+## Open Items
+- [PLACEHOLDER] Source directory mapping for the prebuilt `www/` assets.
+- [PLACEHOLDER] Preferred linter/formatter settings if/when adopted.
+

--- a/DEVIATION_GUIDE.md
+++ b/DEVIATION_GUIDE.md
@@ -1,0 +1,33 @@
+# Deviation (Fork) Guide
+
+A Deviation is any fork or derivative build of CardSpoke. Use this guide to stay aligned with the project’s licensing and ecosystem rules.
+
+## Naming & Branding
+- Do **not** use the name “CardSpoke” or official branding for a Deviation without explicit written permission from JX Holdings, LLC.
+- Provide prominent credit to CardSpoke and JX Holdings, LLC in your README and about screens.
+
+## Mandatory Metadata
+Include the required metadata block for Deviations (see [Extensions Developer Guide](./extensions/DEVELOPER_GUIDE.md)) with `type: "Deviation"`.
+
+## Licenses & Attribution
+- CardSpoke core is licensed under an ISC-style license with branding restrictions (see [LICENSE](./LICENSE)).
+- Your Deviation must retain copyright and permission notices.
+- Credit any AI assistants and contributors used.
+
+## Compatibility & Updates
+- Declare which schemaVersion you support.
+- Document differences from the canonical CardSpoke behavior.
+- Clearly label angled (community) features vs. any official components you include.
+
+## Distribution
+- Monetization is allowed. Be transparent about pricing, support policies, and update cadence.
+- Avoid implying official endorsement unless granted in writing.
+
+## Safety & Data
+- Respect the local-first model; do not collect or transmit data without opt-in.
+- Provide migration and rollback instructions if you diverge from core schemas.
+
+## Open Items
+- [PLACEHOLDER] Required notice template for about pages and splash screens.
+- [PLACEHOLDER] Checklist for validating Deviation compatibility with popular Extensions.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,9 @@
+ISC License with CardSpoke Branding Restriction
+
+Copyright (c) 2024 JX Holdings, LLC
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Branding restriction: The names “CardSpoke” and associated branding may not be used to promote or name Deviations (forks) or other derivatives without explicit written permission from JX Holdings, LLC. Attribution to CardSpoke and JX Holdings, LLC is required in derivative works and Extensions per the project specification.

--- a/README.CAPACITOR.md
+++ b/README.CAPACITOR.md
@@ -1,0 +1,49 @@
+# CardSpoke Capacitor Guide
+
+This guide covers platform prerequisites and workflows for building and running CardSpoke with Capacitor. The web assets are already in `www/`, so the focus is on syncing and opening native shells.
+
+## Prerequisites
+- Node 18+
+- Capacitor CLI (`npx cap` via project devDependencies)
+- Android: Android Studio, Android SDK + platform tools, Java 17+
+- iOS: Xcode, CocoaPods, iOS device/simulator provisioning
+- Optional: platform-specific signing assets for release builds ([PLACEHOLDER] add signing instructions)
+
+## Typical Workflows
+### 1) Sync web assets to native platforms
+```bash
+npm run sync          # Sync all configured platforms
+npm run sync:android  # Sync Android only
+npm run sync:ios      # Sync iOS only
+```
+
+### 2) Open platform workspaces
+```bash
+npm run open:android  # Launch Android Studio with the generated project
+npm run open:ios      # Launch Xcode with the generated project
+```
+
+### 3) Build web assets (when changed)
+Web files in `www/` are already bundled. If you modify them, run:
+```bash
+npm run build
+npm run sync
+```
+
+## Platform Notes
+- **Android:** Ensure `ANDROID_HOME` is set and emulator/device is available. Use Android Studio’s Run/Debug to deploy. For release builds, configure signing configs inside the generated Android project ([PLACEHOLDER] keystore guidance).
+- **iOS:** Run `pod install` inside `ios/App` after syncing if pods change. Use Xcode’s scheme selector to choose device/simulator and run. Configure signing & provisioning profiles in Xcode for distribution ([PLACEHOLDER] distribution profile steps).
+
+## Plugins Used
+- `@capacitor/android`, `@capacitor/ios` – native shells
+- `@capacitor/app` – app lifecycle helpers
+- `@capacitor/preferences` – key/value storage
+- `@capacitor/filesystem` – file persistence
+
+Document any additional plugins you add in this file, including platform-specific caveats, configuration steps, and testing expectations.
+
+## Troubleshooting
+- **Sync failures:** Delete `android/` or `ios/` builds and re-run `npm run sync`. Clear Gradle/DerivedData if platform caches corrupt.
+- **Plugin issues:** Confirm plugin versions match Capacitor major version. Re-run `npx cap doctor` ([PLACEHOLDER] add known-good versions/table if needed).
+- **Platform-specific errors:** Capture logs from `adb logcat` (Android) or Xcode console (iOS) when filing issues.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# CardSpoke
+
+CardSpoke is a lightweight, card-based knowledge system built for extensibility. The core intentionally stays minimal while an extension framework enables themes, plugins, patches, and full-scale mods. Users keep control of their data with a local-first storage model and optional off-device integrations.
+
+## Why CardSpoke
+- **Ultra-lightweight core:** Intentional minimalism keeps performance high and cognitive load low.
+- **Extension-first architecture:** Themes, Patches, Plugins, Mods, Kits, and Expansions let the community expand the product without bloating the core.
+- **User ownership:** Data stays local by default; no hosted data or silent syncs.
+- **Transparent ecosystem:** Clear metadata, authorship, and changelog expectations for all angled (community) content.
+
+## Getting Started
+1. Install dependencies (Node 18+ recommended):
+   ```bash
+   npm install
+   ```
+2. Run the web build (files are pre-generated in `www`):
+   ```bash
+   npm run build
+   ```
+3. Start a Capacitor workflow (see [Capacitor README](./README.CAPACITOR.md)):
+   ```bash
+   npm run sync
+   ```
+4. Run the tests:
+   ```bash
+   npm test
+   ```
+
+## Project Layout
+- `www/` – Prebuilt web assets for the Capacitor shell.
+- `types/` – Type declarations and shared interfaces.
+- `tests/` – Automated tests (uvu).
+- `cardspoke_spec_v1.md` – Canonical specification for philosophy, licensing boundaries, and ecosystem rules.
+- `test-extension-improvements.js` – Scripted checks for extension-related scenarios.
+
+## Extension Framework Overview
+- **Themes:** Cosmetic only; cannot change logic or data.
+- **Patches:** Packaged updates that may alter behavior; official or angled.
+- **Plugins:** Add features without rewriting the core.
+- **Mods:** Change fundamental logic; intentionally high impact.
+- **Kits:** Bundles of Themes/Patches.
+- **Expansions:** Bundles that include Plugins or Mods.
+
+Each Extension must ship mandatory metadata (type, name, version, author, AI assistants, description, date, dependencies, schema compatibility, official/angled flags). See [Extensions Developer Guide](./extensions/DEVELOPER_GUIDE.md).
+
+## Deviation (Fork) Rules
+Deviations are forks/derivatives that must not use the "CardSpoke" name or branding. They must include mandatory metadata, clear credit to CardSpoke and JX Holdings, and avoid implying official endorsement.
+
+## Storage Model
+CardSpoke is local-first (LocalStorage/IndexedDB). Optional off-device storage may be wired through integrations chosen by the user; no automatic sync or hosted data.
+
+## Contributing
+- Follow community and extension guidelines in [Extension Ecosystem Guidelines](./extensions/ECOSYSTEM_GUIDELINES.md).
+- Adhere to safety expectations in [Security & Safety Considerations](./SECURITY_AND_SAFETY.md).
+- Submit issues/PRs with clear metadata and changelog entries.
+- Respect branding restrictions (CardSpoke name/branding cannot be used in forks).
+
+## Support & Questions
+Please open an issue with details about your environment, extensions in use, and schema version. For licensing or branding questions, include your planned distribution channel and whether the work is official or angled.
+
+## Open Items
+- [PLACEHOLDER] Preferred channels for user support and security disclosures.
+- [PLACEHOLDER] Any official branding assets and usage guidelines for community themes.
+

--- a/RELEASE_AND_VERSIONING.md
+++ b/RELEASE_AND_VERSIONING.md
@@ -1,0 +1,38 @@
+# Release & Versioning Notes
+
+CardSpoke differentiates between core updates and Extension-driven changes. Use these guidelines to communicate updates and maintain compatibility.
+
+## Versioning Model
+- Core uses semantic versioning (`MAJOR.MINOR.PATCH`).
+- Schema changes increment `schemaVersion` (see [Schema & Migration Docs](./SCHEMA.md)).
+- Extensions should also use semantic versioning and declare `schema_compatibility`.
+
+## Update Types
+- **Update (Core):** Changes to the canonical app; may bundle Extensions when operating in Bake Mode.
+- **Patch (Extension):** Modular update that can be toggled; may adjust behaviors without full forks.
+
+## Release Checklist (Core)
+- Update changelog with user-facing summary and breaking changes.
+- Record schema changes and migration notes.
+- Verify Extension compatibility; note any known incompatibilities.
+- Regenerate/validate `www/` assets if source changed.
+- Tag release with version and schemaVersion.
+
+## Release Checklist (Extension)
+- Update metadata (version, dependencies, schema compatibility, changelog).
+- Document toggles and uninstall steps.
+- Provide compatibility notes with popular Extensions and Deviations.
+
+## Communication
+- Announce whether a release is **official** or **angled**.
+- Surface risk notes (e.g., Mods that may break compatibility).
+- Include instructions for rollback or disabling problematic Extensions.
+
+## Bake Mode Guidance
+- When merging Extensions into a baked build, document exactly which versions are included.
+- Provide a reproducible manifest so users can rebuild or unbake if needed.
+
+## Open Items
+- [PLACEHOLDER] Preferred changelog format (e.g., Keep a Changelog).
+- [PLACEHOLDER] Distribution channels for official releases and how to submit release candidates.
+

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -1,0 +1,56 @@
+# Schema & Migration Docs
+
+CardSpoke uses a schema version (`schemaVersion`) to track data model changes across the local-first storage stack (LocalStorage/IndexedDB). Use this document to plan migrations and communicate compatibility.
+
+## Current Schema Overview
+- **Schema version:** [PLACEHOLDER] (set current integer once defined)
+- **Data domains:**
+  - Cards and hierarchical relationships
+  - User preferences (theme, layout, toggles)
+  - Extension registry/manifest cache
+  - Local file references (if enabled via Filesystem)
+- **Storage layers:**
+  - LocalStorage for lightweight config
+  - IndexedDB for structured card data and histories
+  - Optional filesystem assets via Capacitor Filesystem (documented per Extension)
+
+## Versioning Rules
+- Increment `schemaVersion` on any backward-incompatible change.
+- Provide migration steps and fallback behavior for every version bump.
+- Keep migrations idempotent and safe to re-run.
+- Log or surface errors when migrations fail; never silently drop user data.
+
+## Migration Template
+For each schema change, record:
+- **From → To:** schemaVersion numbers
+- **Change summary:** What changed and why
+- **Migration steps:** Ordered operations, including data transformations
+- **Fallback behavior:** How the app handles migration failure
+- **Extension impact:** Which Extensions depend on the change
+
+Example:
+```md
+### schemaVersion 3 → 4
+- **Change:** Added per-card tags collection; normalized card links.
+- **Migration:**
+  1. Create `tags` store in IndexedDB.
+  2. Migrate legacy tag arrays on cards to references.
+  3. Validate referential integrity; log any skipped records.
+- **Fallback:** If migration fails, keep database at v3, disable tag-dependent features, prompt user to retry.
+- **Extensions:** Tagging Plugin v2.0+ requires schemaVersion >= 4.
+```
+
+## Fallback & Compatibility
+- On incompatible schema, block Extensions and prompt users with remediation steps.
+- Provide read-only access if feasible when migrations cannot complete.
+- Extensions must declare `schema_compatibility` and refuse to run on older schemas.
+
+## Testing Migrations
+- Add uvu tests for each migration path (happy path + failure cases).
+- Include sample data fixtures for old versions.
+- Exercise downgrade/remove scenarios when possible.
+
+## Documentation Updates
+- Update this file for every schemaVersion change.
+- Reference schema changes in release notes and relevant Extension READMEs.
+

--- a/SECURITY_AND_SAFETY.md
+++ b/SECURITY_AND_SAFETY.md
@@ -1,0 +1,40 @@
+# Security & Safety Considerations
+
+This guide outlines expectations for secure, transparent, and user-respecting behavior in the core app, Extensions, and Deviations.
+
+## Principles
+- **User ownership:** Do not collect or transmit data without explicit consent.
+- **Transparency:** Declare official vs. angled content and list AI assistants involved.
+- **Safety-first:** Prefer safe defaults; fail loudly and recoverably.
+
+## Core App Expectations
+- Keep dependencies minimal and vetted; avoid unnecessary network services.
+- Validate inputs for card content, Extension manifests, and file imports.
+- Treat migrations as critical operations; validate results and avoid silent drops.
+- Surface errors with actionable guidance.
+
+## Extension/Deviation Expectations
+- Do not obfuscate code or hide network calls.
+- Provide uninstall/rollback instructions and cleanup routines.
+- Avoid privileged operations unless required; document all side effects.
+- Provide schema compatibility info and block execution on incompatible schemas.
+
+## Data Handling
+- Avoid storing secrets in LocalStorage; prefer secure platform stores ([PLACEHOLDER] platform-specific secret guidance).
+- Encrypt sensitive exports when feasible; document algorithms and key handling.
+- Minimize retention of logs; avoid logging user content unless necessary for explicit debug flows.
+
+## Reporting & Response
+- Offer a channel for security disclosures ([PLACEHOLDER] security contact email or form).
+- Version advisories and clearly mark impacted versions/Extensions.
+- Provide remediation steps, including how to disable Extensions causing risk.
+
+## Testing & Verification
+- Add tests for permission boundaries, schema compatibility checks, and error handling.
+- For Extensions introducing network access, include mockable clients and offline fallbacks.
+- Audit dependencies for known CVEs before releases.
+
+## Open Items
+- [PLACEHOLDER] Security hardening checklist for Capacitor builds (Android/iOS).
+- [PLACEHOLDER] Static analysis/linting tools if adopted.
+

--- a/STORAGE_AND_PRIVACY.md
+++ b/STORAGE_AND_PRIVACY.md
@@ -1,0 +1,32 @@
+# Storage & Privacy Notes
+
+CardSpoke is local-first. Users own their data, and the app does not silently sync or host information.
+
+## Storage Model
+- **LocalStorage:** Lightweight configuration, session data, and feature toggles.
+- **IndexedDB:** Structured card content, relationships, histories, and Extension registries.
+- **Filesystem (via Capacitor Filesystem):** Optional for attachments or exports; only used when explicitly enabled.
+
+## Default Behavior
+- No automatic cloud sync or telemetry.
+- No analytics or tracking beacons are built into the core.
+- Extensions must not transmit data off-device without explicit, informed consent.
+
+## User Controls
+- Provide clear settings to opt into any off-device storage/integration.
+- Offer data export/import paths (JSON or other agreed formats) to preserve portability.
+- Surface active Extensions and their data-touching permissions.
+
+## Security Considerations
+- Validate file types and sizes before writing to disk.
+- Avoid storing secrets in LocalStorage; prefer secure platform stores where available ([PLACEHOLDER] platform secret-store guidance).
+- Document any encryption used for local caches or exports.
+
+## Incident Response
+- If an Extension or Deviation corrupts data, guide users to restore from backups or exports.
+- Provide steps for clearing caches (LocalStorage/IndexedDB) without losing user backups.
+
+## Open Items
+- [PLACEHOLDER] Recommended backup cadence and storage formats.
+- [PLACEHOLDER] Preferred encrypted export format if adopted.
+

--- a/TEST_GUIDE.md
+++ b/TEST_GUIDE.md
@@ -1,0 +1,37 @@
+# Test Guide
+
+CardSpoke uses `uvu` for automated tests. This guide covers how to run and write tests for core features and Extensions.
+
+## Commands
+- Run all tests:
+  ```bash
+  npm test
+  ```
+- Watch mode:
+  ```bash
+  npm run test:watch
+  ```
+
+## Test Locations
+- `tests/` – Primary uvu suites.
+- `test-extension-improvements.js` – Extension-focused checks.
+
+## Writing Tests
+- Prefer small, deterministic tests with clear assertions.
+- Include fixture data for schema migrations and Extension compatibility.
+- When testing Extensions, validate metadata correctness, toggle behavior, and fallback paths.
+- For UI-affecting Extensions, capture DOM/state expectations and accessibility behaviors where possible.
+
+## Coverage Expectations
+- Core logic: happy path + error handling.
+- Schema changes: migration success and failure handling.
+- Extensions: enable/disable flows, dependency validation, and schema guardrails.
+
+## Reporting
+- Document failing tests with repro steps and environment info (Node version, active Extensions, schemaVersion).
+- Include logs from Capacitor platforms when failures are platform-specific.
+
+## Open Items
+- [PLACEHOLDER] Coverage targets and thresholds.
+- [PLACEHOLDER] Guidance for snapshot/DOM testing setup (if adopted).
+

--- a/extensions/DEVELOPER_GUIDE.md
+++ b/extensions/DEVELOPER_GUIDE.md
@@ -1,0 +1,68 @@
+# Extensions Developer Guide
+
+Build Extensions that fit CardSpoke’s extension-first philosophy. Every Extension must be transparent, metadata-rich, and respectful of user ownership.
+
+## Extension Types
+- **Theme** – Visual changes only; no logic or data modifications.
+- **Patch** – Packaged update; may alter behavior. Official or angled.
+- **Plugin** – Adds features without rewriting the core.
+- **Mod** – Reworks fundamental logic; may break compatibility.
+- **Kit** – Bundle of Themes and/or Patches (no Mods/Plugins).
+- **Expansion** – Bundle that includes at least one Plugin or Mod.
+
+## Mandatory Metadata
+Every Extension or Deviation must include a machine-readable metadata block (JSON or JSONC):
+```json
+{
+  "type": "Theme | Patch | Plugin | Mod | Kit | Expansion | Deviation",
+  "name": "string",
+  "version": "X.Y.Z",
+  "author": "string",
+  "ai_assistants": ["string"],
+  "description": "string",
+  "date_created": "YYYY-MM-DD",
+  "dependencies": ["ExtensionName@Version"],
+  "schema_compatibility": "schemaVersion >= X",
+  "official": false,
+  "angled": true
+}
+```
+- Keep metadata versioned alongside code.
+- Declare schema compatibility based on the current `schemaVersion` (see [Schema & Migration Docs](../SCHEMA.md)).
+- List all AI assistants involved for transparency.
+
+## Packaging & Structure
+- Provide a clear entrypoint (e.g., `main.js` or `index.json`) and README summarizing behavior and toggles.
+- Avoid obfuscated code. Keep logic auditable and failure modes explicit.
+- Include uninstall instructions and state-cleanup steps.
+
+## Compatibility & Toggling
+- Design for toggleability. Extensions—especially Patches and Mods—should fail safely when disabled.
+- Prefer feature flags and guards when modifying core behaviors.
+- For Kits/Expansions, list included Extensions and their versions.
+
+## Data & Storage
+- Respect user ownership. Do not transmit data off-device without explicit opt-in.
+- Use local storage APIs (LocalStorage/IndexedDB) by default; document any filesystem use.
+- Provide migrations for any data you create; version your schemas separately if needed.
+
+## UI & UX Expectations
+- Avoid clutter; keep UI changes minimal unless the Extension is a deliberate overhaul (Mod/Expansion).
+- Ensure readability and keyboard navigation remain intact.
+- Note any accessibility trade-offs in the README.
+
+## Security & Safety
+- Avoid privileged or obfuscated behavior.
+- Validate inputs; fail with clear errors instead of silent corruption.
+- Document removal steps and side effects.
+- See [Security & Safety Considerations](../SECURITY_AND_SAFETY.md) for required practices.
+
+## Distribution & Credit
+- Clarify whether the Extension is **official** or **angled**.
+- Credit CardSpoke, JX Holdings, yourself, and any AI assistants.
+- Include a changelog noting user-impacting changes and schema touches.
+
+## Open Items
+- [PLACEHOLDER] Distribution channel templates (e.g., sample marketplace listing).
+- [PLACEHOLDER] Minimum review checklist for accepting Extensions into an official catalog.
+

--- a/extensions/ECOSYSTEM_GUIDELINES.md
+++ b/extensions/ECOSYSTEM_GUIDELINES.md
@@ -1,0 +1,43 @@
+# Extension Ecosystem & Community Guidelines
+
+These guidelines define expectations for Extensions, community behavior, and transparency.
+
+## Transparency Requirements
+- Declare whether content is **official** or **angled**.
+- Include mandatory metadata (type, name, version, author, AI assistants, description, date, dependencies, schema compatibility, official/angled flags).
+- Provide a changelog and installation/removal steps.
+
+## Quality Expectations
+- Fail safely; avoid data corruption or silent errors.
+- Keep logic auditable; no obfuscation.
+- Provide meaningful error messages and recoverable states.
+- Test with compatible schema versions and document any limitations.
+
+## Behavioral Expectations
+- Respect user ownership and privacy; no unauthorized telemetry.
+- Be explicit about side effects and data created/modified.
+- Avoid implying official endorsement without permission.
+- Credit CardSpoke, JX Holdings, contributors, and AI assistants.
+
+## Classification & Labeling
+- Use canonical types: Theme, Patch, Plugin, Mod, Kit, Expansion.
+- For bundles (Kits/Expansions), list included components and versions.
+- Mark angled content clearly in UIs and marketing.
+
+## Submission & Review (for curated catalogs)
+- Include metadata JSON and README.
+- Supply screenshots or short clips for UI-changing Extensions ([PLACEHOLDER] define screenshot requirements).
+- Provide test notes (uvu or custom) showing core compatibility.
+- Document uninstall steps and data cleanup.
+
+## Safety Checklist
+- Input validation in all user-facing forms.
+- No credential harvesting or disguised network calls.
+- Clear downgrade/removal instructions.
+- Mention any schema changes or migrations and link to [Schema & Migration Docs](../SCHEMA.md).
+
+## Community Conduct
+- Follow the project’s code of conduct.
+- Communicate breaking changes early; version responsibly (semantic versioning recommended).
+- Provide support channels and SLAs if monetizing your Extension ([PLACEHOLDER] SLA template).
+


### PR DESCRIPTION
## Summary
- add comprehensive documentation across core, Capacitor, extensions, schema, releases, storage/privacy, security, testing, and deviation workflows
- choose ISC-style license aligned with project philosophy and record branding restriction
- capture placeholders for open questions (support channels, signing, changelog format, etc.)

## Testing
- npm test *(fails: sample-extensions.test expected 10 sample extensions but found 0)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e1dc333dc8329bc2c954a4de3d00d)