### PR TITLE
Remove obsolete Bake Mode reference from specification

### DIFF
--- a/cardspoke_spec_v1.md
+++ b/cardspoke_spec_v1.md
@@ -174,15 +174,14 @@ CardSpoke does *not*:
 
 ## 8. Content Classification (Official Terminology)
 
-- **Official** — Created by JX Holdings  
-- **Angled** — Community-created  
-- **Extension** — Any modular addition  
-- **Theme / Patch / Plugin / Mod / Kit / Expansion** — Extension subtypes  
-- **Deviation** — Fork  
-- **Schema Version** — Data model version  
-- **Bake Mode** — Output mode that merges Extensions  
-- **Legacy** — Older maintained versions  
-- **Canon** — Core app + this spec  
+- **Official** — Created by JX Holdings
+- **Angled** — Community-created
+- **Extension** — Any modular addition
+- **Theme / Patch / Plugin / Mod / Kit / Expansion** — Extension subtypes
+- **Deviation** — Fork
+- **Schema Version** — Data model version
+- **Legacy** — Older maintained versions
+- **Canon** — Core app + this spec
 - **Ultra-Light** — Performance-focused configuration/theme  
 
 ---


### PR DESCRIPTION
The Bake Mode feature was documented in the spec but never actually implemented in the codebase. This removes the unused terminology definition to keep the documentation accurate and up-to-date.