### PR TITLE
Add comprehensive CardSpoke extension documentation

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,0 +1,95 @@
+# CardSpoke API Reference
+
+This reference documents the surfaces extension developers can rely on: the `CardSpoke.utils` helper bundle and the `CardSpoke_MODS` extension runtime (also exposed as `window.CardSpoke.mods`). It consolidates the runtime contracts that ship in `www/app.js` and the type hints in `types/extensions.d.ts`.
+
+## Global objects
+- **`window.CardSpoke.utils`**: async helpers for card CRUD, tagging, search, accessibility, dataset metadata, and toast UI helpers.
+- **`window.CardSpoke_MODS` / `window.CardSpoke.mods`**: the extension system that registers hooks, dispatches lifecycle events, offers an event bus, and exposes developer tooling.
+- **Legacy aliases**: `window.CIB` and `window.CIB_MODS` mirror the same objects for backward compatibility.
+
+## Extension runtime (`CardSpoke_MODS`)
+
+### Supported hook names
+Implemented hooks are enforced by runtime validation. Unknown hook names log warnings but still register. Hooks may be async.
+
+| Hook | When it fires | Common uses |
+| --- | --- | --- |
+| `onAppInit(ctx)` | First enable or after sync on load | Allocate resources, register listeners, seed state. |
+| `onEnable(ctx)` | After a mod is enabled | Re-attach DOM, rebind hotkeys, reopen sockets. |
+| `onDisable(ctx)` | Before disabling a mod | Tear down DOM/listeners, flush timers. |
+| `onUninstall(ctx)` | Before removal from registry | Purge storage, remove injected styles. |
+| `onCardSave(ctx, card, saveInfo)` | After create/update/duplicate | Derive fields, enforce validation, emit events. |
+| `onCardDelete(ctx, card)` | Before a card is fully removed | Guard deletes, cascade clean-up. |
+| `onCardRender(ctx, card, element)` | After a card’s DOM renders | Inject UI, annotate content, attach buttons. |
+| `onThemeChange(ctx, theme)` | When the app theme toggles | Sync theme variables, re-compute contrast. |
+| `onTypographyChange(ctx, preset)` | When typography preset changes | Recalculate sizes/spacing your mod introduced. |
+| `onHighContrastChange(ctx, enabled)` | When high-contrast mode flips | Adjust palette for accessibility. |
+| `onNavigate(ctx, navState)` | **Planned** navigation change hook | Mirror router state, lazy-load resources. |
+| `onSearch(ctx, query, results)` | **Planned** search completion hook | Rank boosters, log queries, filter results. |
+| `onExport(ctx, data)` | **Planned** pre-export hook | Append metadata, transform payloads. |
+| `onImport(ctx, info)` | **Planned** post-import hook | Normalize incoming data, map legacy fields. |
+
+### Registration and lifecycle
+- **`register(modId, definition)`**: Validates hook names, stores metadata, and resets error counters on success. Called once inside your IIFE.
+- **`enable(modId)` / `disable(modId)`**: Toggle mods persisted in the store; enabling reapplies CSS, runs `onEnable`, then `onAppInit`. Disabling calls `onDisable` before removing styles.
+- **`unregister(modId)`**: Runs `onUninstall`, clears registry entry, removes styles, and evicts persisted mod state.
+- **`syncFromStore()`**: Loads enabled mods from the persisted store, applies CSS, and prunes stale registry entries.
+- **`reload(modId)`**: Executes `onDisable`, clears styles/hooks/error counts, re-runs registration from persisted code+CSS, and then replays `onEnable`/`onAppInit`.
+- **Hook dispatch**: `runHook(hookName, ...args)` fans out to enabled mods, honoring one-time semantics for `onAppInit`. Use `runHookForMod` to target a single mod.
+
+### Context passed to hooks
+The runtime builds a context object per invocation:
+- `modId`: current extension id.
+- `appVersion` / `schemaVersion`: release + schema numbers.
+- `api`: see “Store API” below.
+- `utils`: reference to `CardSpoke.utils` (or `CIB.utils`).
+- `logger`: mod-scoped logger with `log/info/warn/error` prefixes.
+
+### Store API
+`createStoreAPI(modId)` exposes safe, synchronous helpers for hooks:
+- **Read & navigation**: `getAppInfo()`, `getCard(id)`, `listCards()`, `listRootIds()`, `getNavState()`, `navigate(page, opts)`, `goBack()`.
+- **UI feedback**: `showToast(message, type?)`, `markDirty()`.
+- **Card CRUD**: `createCard({ title, body, parentId?, tags? })`, `updateCard(id, updates)`, `deleteCard(id)`.
+- **Tagging**: `getTags(cardId)`, `addTag(cardId, tag)`, `removeTag(cardId, tag)`, `setTags(cardId, tags)`, `getAllTags()`.
+- **Dataset metadata**: `getDatasetMeta()` returns counts, schema/app versions, and dataset name.
+- **Logging**: `logger` plus `log/warn/error/info` wrappers.
+
+### Event bus
+Use `CardSpoke_MODS.events` to coordinate between mods:
+- `on(event, cb)`: subscribe.
+- `off(event, cb)`: unsubscribe.
+- `emit(event, data)`: broadcast.
+- `clear(event?)`: remove listeners for one or all events.
+
+### Developer tools
+`CardSpoke_MODS.devTools` exposes debugging aids:
+- `inspectMod(id)` and `listAllMods()` for visibility into hooks, metadata, load state, and enablement.
+- `getHookStats(modId?)`: timing and failure counters per hook call.
+- `getErrorLog()` / `clearErrorLog()`: global extension error buffer.
+- `testHook(modId, hookName, ...args)`: invoke a hook manually.
+- `getEventListeners()`: per-event subscription counts.
+
+## Utilities API (`CardSpoke.utils`)
+
+### Card & tag helpers
+- `createCard({ title, body?, parentId?, tags? })`: creates, tags, saves, and re-renders UI.
+- `updateCard(cardId, changes)`: updates fields and optionally tags.
+- `getCard(cardId)`: cloned card or `null`.
+- `searchCards(query)`: case-insensitive match against title/body/tags.
+- Tag helpers: `getTags`, `addTag`, `removeTag`, `setTags`, `getAllTags`.
+
+### Dataset metadata
+`getDatasetMeta()` returns dataset name, counts (cards, roots, bookmarks, recent, mods), and schema/app versions.
+
+### UI feedback
+`showToast(message, type = 'info', duration = 3000)` surfaces notifications.
+
+### Accessibility & appearance
+- `getAccessibilitySettings()` returns theme, typography preset, high-contrast flag, and reduced-motion preference.
+- Theme controls: `setTheme(theme)`, `getTheme()`, `onThemeChange(cb)`, `getThemeVariables()` (categorised CSS variables to theme).
+- Typography controls: `setTypography(preset)`, `getTypography()`.
+- High contrast: `setHighContrast(enabled)`, `isHighContrast()`.
+- Motion: `prefersReducedMotion()`.
+
+### Notes
+All helpers are async (Promise-returning) unless noted. Errors are caught and logged to the console; most functions return fallback values instead of throwing.

--- a/docs/EXTENSION_COOKBOOK.md
+++ b/docs/EXTENSION_COOKBOOK.md
@@ -1,0 +1,134 @@
+# Extension Cookbook
+
+Practical recipes for building CardSpoke extensions. Every snippet assumes the runtime provides `window`, `document`, `CardSpoke_MODS`, and `CardSpoke.utils`.
+
+## 1) Minimal extension skeleton
+Use an IIFE that calls `CardSpoke_MODS.register` exactly once. Add metadata and only the hooks you need.
+
+```js
+(() => {
+  CardSpoke_MODS.register('my-mod', {
+    meta: { name: 'My Mod', type: 'Plugin', version: '1.0.0', source: 'community' },
+    onAppInit(ctx) {
+      ctx.logger.info('Ready on schema', ctx.schemaVersion);
+    },
+    onDisable() {
+      // clean up listeners/DOM here
+    }
+  });
+})();
+```
+
+## 2) React to card renders
+Attach UI affordances after the card element exists.
+
+```js
+(() => {
+  CardSpoke_MODS.register('render-highlight', {
+    meta: { name: 'Render Highlight', type: 'Patch', version: '1.0.0' },
+    onCardRender(ctx, card, el) {
+      const badge = document.createElement('span');
+      badge.textContent = `#${card.tags?.[0] || 'untagged'}`;
+      badge.className = 'render-badge';
+      el.appendChild(badge);
+    },
+    onDisable() {
+      document.querySelectorAll('.render-badge').forEach(n => n.remove());
+    }
+  });
+})();
+```
+
+## 3) Guard destructive actions
+Block deletes for certain cards using `onCardDelete`.
+
+```js
+(() => {
+  CardSpoke_MODS.register('protect-parents', {
+    meta: { name: 'Protect Parents', type: 'Patch', version: '1.0.0' },
+    onCardDelete(ctx, card) {
+      if (card.children && card.children.length) {
+        ctx.api.showToast('Cannot delete a card that has children', 'error');
+        return false; // prevent deletion
+      }
+    }
+  });
+})();
+```
+
+## 4) Use the event bus for cross-mod messaging
+
+```js
+(() => {
+  CardSpoke_MODS.register('bus-producer', {
+    meta: { name: 'Bus Producer', type: 'Plugin', version: '1.0.0' },
+    onAppInit(ctx) {
+      setInterval(() => CardSpoke_MODS.events.emit('heartbeat', Date.now()), 5000);
+    },
+    onDisable() {
+      CardSpoke_MODS.events.clear('heartbeat');
+    }
+  });
+
+  CardSpoke_MODS.register('bus-consumer', {
+    meta: { name: 'Bus Consumer', type: 'Plugin', version: '1.0.0' },
+    onAppInit(ctx) {
+      const cb = (timestamp) => ctx.logger.info('Heartbeat', timestamp);
+      CardSpoke_MODS.events.on('heartbeat', cb);
+      this._cb = cb;
+    },
+    onDisable() {
+      if (this._cb) CardSpoke_MODS.events.off('heartbeat', this._cb);
+    }
+  });
+})();
+```
+
+## 5) Tap into accessibility changes
+React to theme, typography, and high-contrast toggles.
+
+```js
+(() => {
+  CardSpoke_MODS.register('a11y-listener', {
+    meta: { name: 'A11y Listener', type: 'Plugin', version: '1.0.0' },
+    onThemeChange(ctx, theme) {
+      ctx.logger.info('Theme changed to', theme);
+    },
+    onTypographyChange(ctx, preset) {
+      ctx.logger.info('Typography preset', preset);
+    },
+    onHighContrastChange(ctx, enabled) {
+      ctx.logger.info('High contrast', enabled);
+    }
+  });
+})();
+```
+
+## 6) Use CardSpoke.utils for quick CRUD
+
+```js
+(async () => {
+  const { id } = await CardSpoke.utils.createCard({ title: 'Cookbook Demo', tags: ['demo'] });
+  await CardSpoke.utils.updateCard(id, { body: 'Filled in later' });
+  const allTags = await CardSpoke.utils.getAllTags();
+  await CardSpoke.utils.showToast(`Created card ${id} with ${allTags.length} tags known`, 'success');
+})();
+```
+
+## 7) Hot reload for rapid iteration
+- Store your extension definition in `store.mods[<id>]` (the built-in UI does this automatically).
+- Call `CardSpoke_MODS.reload('<id>')` after editing `js`/`css` to replay `onDisable`, re-run registration, and re-fire `onAppInit`.
+
+## 8) Error handling and diagnostics
+- `CardSpoke_MODS.devTools.getErrorLog()` returns structured errors captured during hook execution.
+- `CardSpoke_MODS.devTools.getHookStats('<id>')` shows execution counts and timings to spot slow hooks.
+- `CardSpoke_MODS.devTools.testHook('<id>', 'onAppInit')` manually exercises a hook with your own arguments.
+
+## 9) Storage-aware extensions
+When persisting data, pick a namespaced key and clean it up in `onUninstall`. Use `ctx.api.getDatasetMeta()` to check available storage counts and schema versions before writing large payloads.
+
+## 10) Publishing checklist
+- Provide complete metadata (name, type, version, creator, description, source, release date, schema compatibility).
+- Respond to `onDisable` for any DOM or timers you create.
+- Avoid mutating globals directly; prefer hooks, the event bus, and `ctx.api`.
+- Declare any capabilities you expect (e.g., `['tags', 'a11y', 'export']`) so users know what your mod touches.

--- a/docs/MOD_CAPABILITY_AND_TAXONOMY.md
+++ b/docs/MOD_CAPABILITY_AND_TAXONOMY.md
@@ -1,0 +1,34 @@
+# Mod Capability and Taxonomy
+
+This document enumerates the officially recognized extension types in CardSpoke and the common capability areas mods may declare.
+
+## Extension types
+
+CardSpoke recognizes the following `meta.type` values:
+- **Theme**: Cosmetic only; may override CSS variables and typography, but should not mutate data or logic.
+- **Patch**: Targeted behavioral changes or fixes; may intercept hooks such as `onCardDelete` to block actions.
+- **Plugin**: Adds user-facing features without rewriting the core (e.g., inline UI on card render).
+- **Mod**: High-impact changes that can alter core logic and flows.
+- **Kit**: Bundle of themes/patches shipped together.
+- **Expansion**: Bundle that can include plugins or mods alongside themes.
+
+## Capability hints
+
+Extensions can publish a `capabilities` array in `meta` to advertise what they touch. Suggested values:
+- `cards`: Creates/updates/deletes cards.
+- `tags`: Reads or mutates tags.
+- `ui`: Injects DOM or styles.
+- `a11y`: Responds to accessibility hooks (theme/typography/high contrast).
+- `export` / `import`: Hooks into data flows.
+- `navigation`: Responds to `onNavigate`/`onSearch` (planned) to mirror router state.
+- `storage`: Persists extra data; should document keys and cleanup on uninstall.
+
+## Lifecycle expectations
+- **Initialization**: Use `onAppInit` to set up, but keep it idempotent because mods can be hot-reloaded.
+- **Enable/disable**: Always clean up DOM, timers, and listeners in `onDisable` before the runtime removes styles.
+- **Uninstall**: Remove stored keys and release any remote handles inside `onUninstall`.
+- **Errors**: Hook failures are counted and surfaced in the global extension error log; avoid throwing by catching and logging locally.
+
+## Compatibility & schema
+- Declare `schema_compatibility` in metadata when you depend on specific fields or preferences. The current runtime reports `schemaVersion` in the hook context so you can enforce guards.
+- Respect the local-first model: avoid automatically syncing data off-device, and prefer the provided storage drivers or dataset metadata to gauge available space.

--- a/docs/SAMPLE_EXTENSIONS.md
+++ b/docs/SAMPLE_EXTENSIONS.md
@@ -1,0 +1,24 @@
+# Sample Extensions
+
+Use these ready-made examples as starting points. They align with the runtime APIs described in the API Reference.
+
+## Card Tagger (Plugin)
+- **Purpose:** Adds inline chips on every card render so users can apply predefined tags.
+- **Hooks:** `onAppInit` for logging, `onCardRender` to inject buttons, `onDisable` to remove injected DOM, `onUninstall` to clear storage.
+- **Notes:** Namespaces its storage key (`card-tagger-v1`) and applies CSS via rounded chips with focus states.
+
+## Nocturne (Theme)
+- **Purpose:** Purely cosmetic theme with deep navy background and accent blues.
+- **Hooks:** Registers metadata only (no JS hooks); styling is entirely in CSS.
+- **Notes:** Demonstrates how a theme can ship CSS without behavioral hooks while still declaring metadata.
+
+## Readonly Parents (Patch)
+- **Purpose:** Prevents deleting cards that have children.
+- **Hooks:** `onCardDelete` to guard the delete flow; `onDisable` is present even though no DOM is added.
+- **Notes:** Shows how to abort a destructive action by returning `false` inside a hook.
+
+## How to reuse
+1. Copy the JSON from the recipes file in `extensions/AI_EXTENSION_RECIPES.md`.
+2. Replace `<replace: creator>` and adjust description/version as needed.
+3. Keep hook names within the allowed set and ensure `onDisable` is present for any DOM/listener work.
+4. If you add storage, pick a namespaced key and clear it in `onUninstall`.

--- a/docs/SCHEMA_REFERENCE.md
+++ b/docs/SCHEMA_REFERENCE.md
@@ -1,0 +1,37 @@
+# Schema Reference
+
+This file summarizes the persisted data model and schema versioning rules used by CardSpoke.
+
+## Versioning
+- **Current schema version:** 4.
+- Runtime constant `SCHEMA_VERSION` is exported from `www/modules/core/state.js` and surfaced to mods via both `CardSpoke.utils.getDatasetMeta()` and the hook context.
+- Bump the schema version on any backward-incompatible change and ship an accompanying migration plan.
+
+## Core domains
+- **Cards:** `cards` map keyed by id, with `rootOrder` tracking top-level ordering and `children` arrays on each card for hierarchy.
+- **Extensions:** `mods` registry stores extension metadata, `enabled` flag, and bundled JS/CSS for replay at startup.
+- **User preferences:** `viewMode`, `activeTheme`, typography preset (`cardspoke_typography`), high contrast (`cardspoke_highcontrast`), and rich text flags (`cardspoke_richtext`).
+- **Navigation & history:** `navState` plus `recentCards` and `bookmarks` collections for quick recall.
+- **Trash/undo:** Undo/redo stacks and `trashBin` entries keep recovery history.
+
+## Default store shape
+A new dataset starts with:
+```
+rootOrder: []
+cards: {}
+mods: {}
+bookmarks: []
+recentCards: []
+viewMode: 'normal'
+activeTheme: 'light'
+richTextEnabled: false
+```
+
+## Storage layers
+- **LocalStorage**: lightweight config (preferences, dev mode, active dataset id, typography/high-contrast flags).
+- **IndexedDB**: structured datasets via the `datasets` object store.
+- **Optional cloud/file drivers**: Google Drive, OneDrive, WebDAV (see Storage Driver Interface) used only when explicitly configured by the user.
+
+## Migration expectations
+- Keep migrations idempotent and provide fallbacks if a migration fails (e.g., block extensions, fall back to read-only view).
+- Document every migration with from→to versions, change summary, steps, fallback behavior, and extension impact.

--- a/docs/STORAGE_DRIVER_INTERFACE.md
+++ b/docs/STORAGE_DRIVER_INTERFACE.md
@@ -1,0 +1,30 @@
+# Storage Driver Interface
+
+CardSpoke abstracts persistence behind a `StorageDriver` contract so datasets can live in LocalStorage, IndexedDB, or optional cloud backends.
+
+## Interface
+Drivers extend the abstract `StorageDriver` class and must implement:
+- `init(config)`: prepare credentials or connections.
+- `get(key)`: fetch a value.
+- `set(key, value)`: write a value.
+- `remove(key)`: delete a value.
+- `list(prefix?)`: enumerate stored keys, optionally filtered by prefix.
+- `getSize()`: return approximate size (bytes or characters).
+- `getKind()`: string identifier for the driver.
+
+## Built-in drivers
+- **IndexedDBDriver (`kind: 'indexeddb'`)**: stores datasets in the `datasets` object store inside `CardSpokeDB` (configurable names). Uses read/write transactions per operation and computes size by summing serialized values.
+- **LocalStorageDriver (`kind: 'localstorage'`)**: prefix-based keys (default `cardspoke_`); JSON serializes values and calculates size from stored string lengths.
+- **GoogleDriveDriver (`kind: 'googledrive'`)**: OAuth via Google Identity Services; reads/writes a JSON file (default `cardspoke.json`) using Drive v3 APIs. Requires developer-supplied client id; surfaces toast errors on failures.
+- **OneDriveDriver (`kind: 'onedrive'`)**: Auth via MSAL; also stores a JSON payload in the user’s drive and uses PUT/PATCH operations to update it.
+- **WebDAVDriver (`kind: 'webdav'`)**: Basic-auth to a configured endpoint; reads/writes a JSON file (default `cardspoke.json`) and warns about CORS when misconfigured.
+
+## Dataset manager expectations
+- Each dataset tracks `id`, `name`, `storage` driver + config, `pin` (optional), and timestamps.
+- Sensitive fields (e.g., WebDAV password) are stripped before metadata is saved to LocalStorage.
+- Switching datasets validates PINs and persists the active dataset id; deleting a dataset cascades removal across all keys in that driver.
+- `getDatasetInfo()` returns driver kind, size in bytes (formatted), item count, and timestamps to surface in diagnostics UIs.
+
+## Usage notes
+- Cloud drivers are opt-in and require explicit configuration; the app defaults to IndexedDB/LocalStorage.
+- Extensions should prefer `CardSpoke.utils.getDatasetMeta()` or the mod `ctx.api.getDatasetMeta()` instead of directly touching drivers; this keeps storage decisions centralized.


### PR DESCRIPTION
## Summary
- add a detailed API reference covering CardSpoke.utils and the CardSpoke_MODS extension runtime
- provide cookbook guidance, capability taxonomy, and schema/storage references for extension developers
- include sample extension outlines to jump-start mod creation

## Testing
- not run (documentation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e351eeec883299de9a6398ed73cf8)