### PR TITLE
Add 9 working sample mods (3 per layer) with validation tests

### DIFF
--- a/sample-mods/apps/focus-mode.json
+++ b/sample-mods/apps/focus-mode.json
@@ -1,0 +1,19 @@
+{
+  "id": "focus-mode",
+  "manifest": {
+    "name": "Focus Mode",
+    "version": "1.0.0",
+    "author": "CardSpoke Community",
+    "description": "Strips the app down to a minimal writing experience by hiding navigation and extras",
+    "layer": "app",
+    "compatibility": ">=0.16.0"
+  },
+  "config": {},
+  "css": "body.mod-focus-active .breadcrumb { display: none !important; } body.mod-focus-active footer { display: none !important; } body.mod-focus-active .card-item { border: none !important; box-shadow: none !important; padding: 16px 24px !important; max-width: 720px; margin: 0 auto; } body.mod-focus-active textarea, body.mod-focus-active .card-body { font-size: 17px !important; line-height: 1.7 !important; } #mod-focus-toggle { position: fixed; top: 8px; right: 8px; z-index: 10000; padding: 4px 12px; border-radius: 4px; border: 1px solid rgba(128,128,128,0.3); background: rgba(128,128,128,0.1); cursor: pointer; font-size: 12px; opacity: 0.5; transition: opacity 0.2s; } #mod-focus-toggle:hover { opacity: 1; }",
+  "js": "CardSpoke_MODS.register('focus-mode', {\n  onLoad: function(ctx) {\n    if (document.getElementById('mod-focus-toggle')) return;\n    var btn = document.createElement('button');\n    btn.id = 'mod-focus-toggle';\n    btn.textContent = 'Focus';\n    btn.title = 'Toggle Focus Mode';\n    btn.setAttribute('aria-label', 'Toggle focus mode');\n    btn.addEventListener('click', function() {\n      document.body.classList.toggle('mod-focus-active');\n      btn.textContent = document.body.classList.contains('mod-focus-active') ? 'Exit Focus' : 'Focus';\n    });\n    document.body.appendChild(btn);\n    ctx.logger.info('Focus Mode ready');\n  },\n  onDisable: function(ctx) {\n    document.body.classList.remove('mod-focus-active');\n    var btn = document.getElementById('mod-focus-toggle');\n    if (btn) btn.remove();\n    ctx.logger.info('Focus Mode disabled');\n  },\n  onUninstall: function(ctx) {\n    document.body.classList.remove('mod-focus-active');\n    var btn = document.getElementById('mod-focus-toggle');\n    if (btn) btn.remove();\n  }\n});",
+  "overrides": {
+    "hideMenuItems": ["menuRecentCards"],
+    "disableFeatures": ["recentCards"]
+  },
+  "enabled": false
+}

--- a/sample-mods/apps/minimal-writer.json
+++ b/sample-mods/apps/minimal-writer.json
@@ -1,0 +1,20 @@
+{
+  "id": "minimal-writer",
+  "manifest": {
+    "name": "Minimal Writer",
+    "version": "1.0.0",
+    "author": "CardSpoke Community",
+    "description": "Transforms CardSpoke into a distraction-free writing app by hiding non-essential features",
+    "layer": "app",
+    "compatibility": ">=0.16.0"
+  },
+  "config": {},
+  "css": "body.mod-minimal-writer header { background: transparent !important; border-bottom: none !important; box-shadow: none !important; } body.mod-minimal-writer .card-item { border: none !important; box-shadow: none !important; background: transparent !important; max-width: 680px; margin: 0 auto; padding: 20px 0; } body.mod-minimal-writer textarea, body.mod-minimal-writer .card-body { font-family: Georgia, 'Times New Roman', serif !important; font-size: 18px !important; line-height: 1.8 !important; } body.mod-minimal-writer .card-item .card-title input, body.mod-minimal-writer .card-item .card-title { font-family: Georgia, 'Times New Roman', serif !important; font-size: 24px !important; font-weight: bold !important; }",
+  "js": "CardSpoke_MODS.register('minimal-writer', {\n  onLoad: function(ctx) {\n    document.body.classList.add('mod-minimal-writer');\n    ctx.logger.info('Minimal Writer activated');\n  },\n  onDisable: function(ctx) {\n    document.body.classList.remove('mod-minimal-writer');\n    ctx.logger.info('Minimal Writer deactivated');\n  },\n  onUninstall: function(ctx) {\n    document.body.classList.remove('mod-minimal-writer');\n  }\n});",
+  "overrides": {
+    "appName": "Writer",
+    "hideMenuItems": ["menuRecentCards", "menuBookmarks"],
+    "disableFeatures": ["bookmarks", "recentCards"]
+  },
+  "enabled": false
+}

--- a/sample-mods/apps/research-hub.json
+++ b/sample-mods/apps/research-hub.json
@@ -1,0 +1,21 @@
+{
+  "id": "research-hub",
+  "manifest": {
+    "name": "Research Hub",
+    "version": "1.0.0",
+    "author": "CardSpoke Community",
+    "description": "Rebrands CardSpoke as a research-focused tool with a custom menu item for research stats",
+    "layer": "app",
+    "compatibility": ">=0.16.0"
+  },
+  "config": {},
+  "css": "#mod-research-stats { position: fixed; bottom: 0; left: 0; right: 0; background: rgba(40,40,60,0.95); color: #ccc; padding: 6px 16px; font-size: 12px; font-family: monospace; z-index: 9998; display: none; border-top: 1px solid rgba(100,100,200,0.3); } #mod-research-stats.visible { display: flex; gap: 24px; justify-content: center; } #mod-research-stats .stat-item { display: inline-block; } #mod-research-stats .stat-value { color: #7cacf8; font-weight: bold; }",
+  "js": "CardSpoke_MODS.register('research-hub', {\n  onLoad: function(ctx) {\n    if (document.getElementById('mod-research-stats')) return;\n    var bar = document.createElement('div');\n    bar.id = 'mod-research-stats';\n    document.body.appendChild(bar);\n    this._updateStats = function() {\n      var meta = storeAPI.getDatasetMeta();\n      var cards = storeAPI.listCards();\n      var totalWords = cards.reduce(function(sum, c) {\n        var text = (c.title || '') + ' ' + (c.body || '');\n        return sum + text.trim().split(/\\s+/).filter(function(w) { return w.length > 0; }).length;\n      }, 0);\n      var totalTags = storeAPI.getAllTags().length;\n      bar.innerHTML = '<span class=\"stat-item\">Cards: <span class=\"stat-value\">' + meta.cardCount + '</span></span>' +\n        '<span class=\"stat-item\">Words: <span class=\"stat-value\">' + totalWords + '</span></span>' +\n        '<span class=\"stat-item\">Tags: <span class=\"stat-value\">' + totalTags + '</span></span>' +\n        '<span class=\"stat-item\">Bookmarks: <span class=\"stat-value\">' + meta.bookmarkCount + '</span></span>';\n    };\n    this._updateStats();\n    bar.classList.add('visible');\n    ctx.logger.info('Research Hub loaded');\n  },\n  onCardSave: function(ctx, card, saveInfo) {\n    if (this._updateStats) this._updateStats();\n  },\n  onDisable: function(ctx) {\n    var bar = document.getElementById('mod-research-stats');\n    if (bar) bar.remove();\n    ctx.logger.info('Research Hub disabled');\n  },\n  onUninstall: function(ctx) {\n    var bar = document.getElementById('mod-research-stats');\n    if (bar) bar.remove();\n  }\n});",
+  "overrides": {
+    "appName": "Research Hub",
+    "customMenuItems": [
+      { "id": "toggleResearchStats", "label": "Toggle Research Stats", "section": "actions" }
+    ]
+  },
+  "enabled": false
+}

--- a/sample-mods/features/card-timestamps.json
+++ b/sample-mods/features/card-timestamps.json
@@ -1,0 +1,16 @@
+{
+  "id": "card-timestamps",
+  "manifest": {
+    "name": "Card Timestamps",
+    "version": "1.0.0",
+    "author": "CardSpoke Community",
+    "description": "Shows human-readable created and updated timestamps on each card",
+    "layer": "feature",
+    "compatibility": ">=0.16.0"
+  },
+  "config": {},
+  "css": ".mod-timestamp { display: block; font-size: 10px; margin-top: 6px; padding-top: 4px; border-top: 1px solid rgba(128,128,128,0.2); opacity: 0.6; font-family: monospace; line-height: 1.5; } .mod-timestamp:hover { opacity: 1; }",
+  "js": "CardSpoke_MODS.register('card-timestamps', {\n  onLoad: function(ctx) {\n    ctx.logger.info('Card Timestamps loaded');\n  },\n  onCardRender: function(ctx, card, element) {\n    if (!card || !element) return;\n    var existing = element.querySelector('.mod-timestamp');\n    if (existing) existing.remove();\n    var created = card.createdAt ? new Date(card.createdAt).toLocaleString() : 'unknown';\n    var updated = card.updatedAt ? new Date(card.updatedAt).toLocaleString() : 'unknown';\n    var el = document.createElement('div');\n    el.className = 'mod-timestamp';\n    el.textContent = 'Created: ' + created + ' | Updated: ' + updated;\n    element.appendChild(el);\n  },\n  onDisable: function(ctx) {\n    var stamps = document.querySelectorAll('.mod-timestamp');\n    stamps.forEach(function(s) { s.remove(); });\n    ctx.logger.info('Card Timestamps disabled');\n  }\n});",
+  "overrides": {},
+  "enabled": false
+}

--- a/sample-mods/features/quick-note.json
+++ b/sample-mods/features/quick-note.json
@@ -1,0 +1,16 @@
+{
+  "id": "quick-note",
+  "manifest": {
+    "name": "Quick Note",
+    "version": "1.0.0",
+    "author": "CardSpoke Community",
+    "description": "Adds a floating button to quickly create a new card from anywhere in the app",
+    "layer": "feature",
+    "compatibility": ">=0.16.0"
+  },
+  "config": {},
+  "css": "#mod-quick-note-btn { position: fixed; bottom: 24px; right: 24px; width: 56px; height: 56px; border-radius: 50%; background: #4a90d9; color: #fff; border: none; font-size: 28px; line-height: 56px; text-align: center; cursor: pointer; box-shadow: 0 4px 12px rgba(0,0,0,0.3); z-index: 9999; transition: transform 0.15s ease, background 0.15s ease; } #mod-quick-note-btn:hover { transform: scale(1.1); background: #357abd; } #mod-quick-note-btn:active { transform: scale(0.95); }",
+  "js": "CardSpoke_MODS.register('quick-note', {\n  onLoad: function(ctx) {\n    if (document.getElementById('mod-quick-note-btn')) return;\n    var btn = document.createElement('button');\n    btn.id = 'mod-quick-note-btn';\n    btn.textContent = '+';\n    btn.title = 'Quick Note: Create a new card';\n    btn.setAttribute('aria-label', 'Create a new card');\n    btn.addEventListener('click', function() {\n      var title = 'Quick Note ' + new Date().toLocaleString();\n      var id = storeAPI.createCard({ title: title, body: '' });\n      if (id) {\n        storeAPI.showToast('Created: ' + title, 'success');\n      }\n    });\n    document.body.appendChild(btn);\n    ctx.logger.info('Quick Note button added');\n  },\n  onDisable: function(ctx) {\n    var btn = document.getElementById('mod-quick-note-btn');\n    if (btn) btn.remove();\n    ctx.logger.info('Quick Note button removed');\n  },\n  onUninstall: function(ctx) {\n    var btn = document.getElementById('mod-quick-note-btn');\n    if (btn) btn.remove();\n  }\n});",
+  "overrides": {},
+  "enabled": false
+}

--- a/sample-mods/features/word-counter.json
+++ b/sample-mods/features/word-counter.json
@@ -1,0 +1,16 @@
+{
+  "id": "word-counter",
+  "manifest": {
+    "name": "Word Counter",
+    "version": "1.0.0",
+    "author": "CardSpoke Community",
+    "description": "Displays a live word and character count badge on each card during rendering",
+    "layer": "feature",
+    "compatibility": ">=0.16.0"
+  },
+  "config": {},
+  "css": ".mod-word-count { display: inline-block; font-size: 11px; padding: 2px 8px; margin-top: 4px; border-radius: 10px; background: rgba(128,128,128,0.15); color: inherit; opacity: 0.7; font-family: monospace; } .mod-word-count:hover { opacity: 1; }",
+  "js": "CardSpoke_MODS.register('word-counter', {\n  onLoad: function(ctx) {\n    ctx.logger.info('Word Counter loaded');\n  },\n  onCardRender: function(ctx, card, element) {\n    if (!card || !element) return;\n    var existing = element.querySelector('.mod-word-count');\n    if (existing) existing.remove();\n    var text = (card.body || '') + ' ' + (card.title || '');\n    var words = text.trim().split(/\\s+/).filter(function(w) { return w.length > 0; }).length;\n    var chars = text.trim().length;\n    var badge = document.createElement('span');\n    badge.className = 'mod-word-count';\n    badge.textContent = words + ' words / ' + chars + ' chars';\n    badge.title = 'Word and character count';\n    element.appendChild(badge);\n  },\n  onDisable: function(ctx) {\n    var badges = document.querySelectorAll('.mod-word-count');\n    badges.forEach(function(b) { b.remove(); });\n    ctx.logger.info('Word Counter disabled');\n  }\n});",
+  "overrides": {},
+  "enabled": false
+}

--- a/sample-mods/themes/nocturne.json
+++ b/sample-mods/themes/nocturne.json
@@ -1,0 +1,16 @@
+{
+  "id": "nocturne-theme",
+  "manifest": {
+    "name": "Nocturne",
+    "version": "1.0.0",
+    "author": "CardSpoke Community",
+    "description": "A deep purple and midnight blue dark theme with soft accent colors",
+    "layer": "theme",
+    "compatibility": ">=0.16.0"
+  },
+  "config": {},
+  "css": ":root { --bg-primary: #1a1025; --bg-secondary: #2d1f3d; --bg-card: #251735; --text-primary: #e8dff0; --text-secondary: #b8a5c8; --accent: #9b6dcc; --accent-hover: #b388e0; --border-color: #3d2a55; --shadow-color: rgba(155,109,204,0.15); } body { background-color: var(--bg-primary) !important; color: var(--text-primary) !important; } .card, .card-item { background-color: var(--bg-card) !important; border-color: var(--border-color) !important; color: var(--text-primary) !important; box-shadow: 0 2px 8px var(--shadow-color) !important; } .card-item:hover { border-color: var(--accent) !important; } header, .header { background-color: var(--bg-secondary) !important; border-bottom-color: var(--border-color) !important; } button { border-color: var(--border-color) !important; color: var(--text-primary) !important; } button:hover { background-color: var(--accent) !important; color: #fff !important; } .modal-content, .menu-section { background-color: var(--bg-secondary) !important; border-color: var(--border-color) !important; color: var(--text-primary) !important; } input, textarea, select { background-color: var(--bg-card) !important; border-color: var(--border-color) !important; color: var(--text-primary) !important; } input:focus, textarea:focus { border-color: var(--accent) !important; outline-color: var(--accent) !important; } .tag { background-color: var(--accent) !important; color: #fff !important; } .breadcrumb a, a { color: var(--accent) !important; } .toast { background-color: var(--bg-secondary) !important; color: var(--text-primary) !important; border-left-color: var(--accent) !important; }",
+  "js": "",
+  "overrides": {},
+  "enabled": false
+}

--- a/sample-mods/themes/ocean-breeze.json
+++ b/sample-mods/themes/ocean-breeze.json
@@ -1,0 +1,16 @@
+{
+  "id": "ocean-theme",
+  "manifest": {
+    "name": "Ocean Breeze",
+    "version": "1.0.0",
+    "author": "CardSpoke Community",
+    "description": "A cool, calming blue-green theme reminiscent of ocean waters",
+    "layer": "theme",
+    "compatibility": ">=0.16.0"
+  },
+  "config": {},
+  "css": ":root { --bg-primary: #0f1e2e; --bg-secondary: #162d42; --bg-card: #1a3550; --text-primary: #d4eaf7; --text-secondary: #8bb8d4; --accent: #29b6a8; --accent-hover: #35d4c4; --border-color: #1f4a6e; --shadow-color: rgba(41,182,168,0.12); } body { background-color: var(--bg-primary) !important; color: var(--text-primary) !important; } .card, .card-item { background-color: var(--bg-card) !important; border-color: var(--border-color) !important; color: var(--text-primary) !important; box-shadow: 0 2px 8px var(--shadow-color) !important; } .card-item:hover { border-color: var(--accent) !important; } header, .header { background-color: var(--bg-secondary) !important; border-bottom-color: var(--border-color) !important; } button { border-color: var(--border-color) !important; color: var(--text-primary) !important; } button:hover { background-color: var(--accent) !important; color: #fff !important; } .modal-content, .menu-section { background-color: var(--bg-secondary) !important; border-color: var(--border-color) !important; color: var(--text-primary) !important; } input, textarea, select { background-color: var(--bg-card) !important; border-color: var(--border-color) !important; color: var(--text-primary) !important; } input:focus, textarea:focus { border-color: var(--accent) !important; outline-color: var(--accent) !important; } .tag { background-color: var(--accent) !important; color: #fff !important; } .breadcrumb a, a { color: var(--accent) !important; } .toast { background-color: var(--bg-secondary) !important; color: var(--text-primary) !important; border-left-color: var(--accent) !important; }",
+  "js": "",
+  "overrides": {},
+  "enabled": false
+}

--- a/sample-mods/themes/sunrise.json
+++ b/sample-mods/themes/sunrise.json
@@ -1,0 +1,16 @@
+{
+  "id": "sunrise-theme",
+  "manifest": {
+    "name": "Sunrise",
+    "version": "1.0.0",
+    "author": "CardSpoke Community",
+    "description": "A warm, golden light theme inspired by morning sunlight",
+    "layer": "theme",
+    "compatibility": ">=0.16.0"
+  },
+  "config": {},
+  "css": ":root { --bg-primary: #fdf6ec; --bg-secondary: #fff8f0; --bg-card: #ffffff; --text-primary: #3d2c1e; --text-secondary: #7a6050; --accent: #e8832a; --accent-hover: #d4721a; --border-color: #f0d9b5; --shadow-color: rgba(232,131,42,0.1); } body { background-color: var(--bg-primary) !important; color: var(--text-primary) !important; } .card, .card-item { background-color: var(--bg-card) !important; border-color: var(--border-color) !important; color: var(--text-primary) !important; box-shadow: 0 2px 8px var(--shadow-color) !important; } .card-item:hover { border-color: var(--accent) !important; } header, .header { background-color: var(--bg-secondary) !important; border-bottom-color: var(--border-color) !important; } button { border-color: var(--border-color) !important; color: var(--text-primary) !important; } button:hover { background-color: var(--accent) !important; color: #fff !important; } .modal-content, .menu-section { background-color: var(--bg-secondary) !important; border-color: var(--border-color) !important; color: var(--text-primary) !important; } input, textarea, select { background-color: var(--bg-card) !important; border-color: var(--border-color) !important; color: var(--text-primary) !important; } input:focus, textarea:focus { border-color: var(--accent) !important; outline-color: var(--accent) !important; } .tag { background-color: var(--accent) !important; color: #fff !important; } .breadcrumb a, a { color: var(--accent) !important; } .toast { background-color: var(--bg-secondary) !important; color: var(--text-primary) !important; border-left-color: var(--accent) !important; }",
+  "js": "",
+  "overrides": {},
+  "enabled": false
+}

--- a/tests/sample-extensions.test.js
+++ b/tests/sample-extensions.test.js
@@ -2,11 +2,18 @@
  * Mod System Test Suite
  *
  * Validates the new JSON-based mod loading system including
- * package validation, risk assessment, and mod format compliance.
+ * package validation, risk assessment, mod format compliance,
+ * and the actual sample mod files.
  */
 
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
+import { readFileSync, readdirSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // ==========================================================================
 // Mod Package Format Tests
@@ -32,6 +39,31 @@ function createValidModPackage(overrides = {}) {
     overrides: overrides.overrides || {},
     enabled: overrides.enabled !== undefined ? overrides.enabled : false
   };
+}
+
+function validateModPackage(pkg) {
+  const errors = [];
+  if (!pkg || typeof pkg !== 'object') return { valid: false, errors: ['Not an object'] };
+  if (!pkg.id || typeof pkg.id !== 'string') errors.push('Missing or invalid "id"');
+  if (pkg.id && !/^[a-z0-9-]+$/.test(pkg.id)) errors.push('ID must be lowercase alphanumeric with hyphens');
+  if (!pkg.manifest || typeof pkg.manifest !== 'object') {
+    errors.push('Missing "manifest" object');
+  } else {
+    if (!pkg.manifest.name) errors.push('Missing manifest.name');
+    if (!pkg.manifest.version) errors.push('Missing manifest.version');
+    if (!pkg.manifest.author) errors.push('Missing manifest.author');
+    if (!pkg.manifest.layer) errors.push('Missing manifest.layer');
+    if (pkg.manifest.layer && !VALID_LAYERS.includes(pkg.manifest.layer)) {
+      errors.push('Invalid manifest.layer: ' + pkg.manifest.layer);
+    }
+  }
+  if (pkg.manifest && pkg.manifest.layer === 'theme' && pkg.js && pkg.js.trim().length > 0) {
+    errors.push('Theme-layer mods cannot contain JavaScript');
+  }
+  if (pkg.overrides && Object.keys(pkg.overrides).length > 0 && pkg.manifest && pkg.manifest.layer !== 'app') {
+    errors.push('Only app-layer mods can use overrides');
+  }
+  return { valid: errors.length === 0, errors };
 }
 
 test('valid mod package has all required fields', () => {
@@ -157,7 +189,6 @@ test('theme mod is lowest risk', () => {
     css: ':root { --bg: blue; }',
     js: ''
   });
-  // Theme with no JS should be SAFE
   assert.is(pkg.manifest.layer, 'theme');
   assert.is(pkg.js, '');
 });
@@ -181,6 +212,116 @@ test('app mod with overrides is highest risk', () => {
   });
   assert.is(pkg.manifest.layer, 'app');
   assert.ok(pkg.overrides.disableFeatures, 'can disable features');
+});
+
+// ==========================================================================
+// Sample Mod File Validation Tests
+// ==========================================================================
+
+const sampleModsDir = join(__dirname, '..', 'sample-mods');
+
+function loadSampleMods(subdir) {
+  const dir = join(sampleModsDir, subdir);
+  const files = readdirSync(dir).filter(f => f.endsWith('.json'));
+  return files.map(f => {
+    const raw = readFileSync(join(dir, f), 'utf8');
+    return { filename: f, pkg: JSON.parse(raw) };
+  });
+}
+
+test('all sample theme mods are valid JSON and pass validation', () => {
+  const mods = loadSampleMods('themes');
+  assert.is(mods.length, 3, 'should have exactly 3 theme mods');
+  mods.forEach(({ filename, pkg }) => {
+    const result = validateModPackage(pkg);
+    assert.ok(result.valid, `${filename}: ${result.errors.join(', ')}`);
+    assert.is(pkg.manifest.layer, 'theme', `${filename} should be theme layer`);
+    assert.is(pkg.js, '', `${filename} theme must have no JS`);
+    assert.ok(pkg.css.length > 0, `${filename} theme should have CSS`);
+  });
+});
+
+test('all sample feature mods are valid JSON and pass validation', () => {
+  const mods = loadSampleMods('features');
+  assert.is(mods.length, 3, 'should have exactly 3 feature mods');
+  mods.forEach(({ filename, pkg }) => {
+    const result = validateModPackage(pkg);
+    assert.ok(result.valid, `${filename}: ${result.errors.join(', ')}`);
+    assert.is(pkg.manifest.layer, 'feature', `${filename} should be feature layer`);
+    assert.ok(pkg.js.length > 0, `${filename} feature should have JS`);
+  });
+});
+
+test('all sample app mods are valid JSON and pass validation', () => {
+  const mods = loadSampleMods('apps');
+  assert.is(mods.length, 3, 'should have exactly 3 app mods');
+  mods.forEach(({ filename, pkg }) => {
+    const result = validateModPackage(pkg);
+    assert.ok(result.valid, `${filename}: ${result.errors.join(', ')}`);
+    assert.is(pkg.manifest.layer, 'app', `${filename} should be app layer`);
+    assert.ok(pkg.overrides && Object.keys(pkg.overrides).length > 0, `${filename} app should have overrides`);
+  });
+});
+
+test('all sample mods have unique IDs', () => {
+  const allMods = [
+    ...loadSampleMods('themes'),
+    ...loadSampleMods('features'),
+    ...loadSampleMods('apps')
+  ];
+  const ids = allMods.map(m => m.pkg.id);
+  const uniqueIds = new Set(ids);
+  assert.is(uniqueIds.size, ids.length, 'All mod IDs must be unique: ' + ids.join(', '));
+});
+
+test('all sample mods register hooks via CardSpoke_MODS.register in their JS', () => {
+  const featureMods = loadSampleMods('features');
+  const appMods = loadSampleMods('apps');
+  [...featureMods, ...appMods].forEach(({ filename, pkg }) => {
+    if (pkg.js && pkg.js.trim().length > 0) {
+      assert.ok(
+        pkg.js.includes('CardSpoke_MODS.register('),
+        `${filename} JS should register via CardSpoke_MODS.register()`
+      );
+    }
+  });
+});
+
+test('all sample mods use their own ID in register calls', () => {
+  const featureMods = loadSampleMods('features');
+  const appMods = loadSampleMods('apps');
+  [...featureMods, ...appMods].forEach(({ filename, pkg }) => {
+    if (pkg.js && pkg.js.trim().length > 0) {
+      assert.ok(
+        pkg.js.includes("'" + pkg.id + "'") || pkg.js.includes('"' + pkg.id + '"'),
+        `${filename} JS should register with its own ID '${pkg.id}'`
+      );
+    }
+  });
+});
+
+test('all sample mods start disabled', () => {
+  const allMods = [
+    ...loadSampleMods('themes'),
+    ...loadSampleMods('features'),
+    ...loadSampleMods('apps')
+  ];
+  allMods.forEach(({ filename, pkg }) => {
+    assert.is(pkg.enabled, false, `${filename} should start disabled`);
+  });
+});
+
+test('feature and app mods implement onDisable for clean teardown', () => {
+  const featureMods = loadSampleMods('features');
+  const appMods = loadSampleMods('apps');
+  [...featureMods, ...appMods].forEach(({ filename, pkg }) => {
+    if (pkg.js && pkg.js.trim().length > 0) {
+      assert.ok(
+        pkg.js.includes('onDisable'),
+        `${filename} should implement onDisable hook for clean teardown`
+      );
+    }
+  });
 });
 
 test.run();


### PR DESCRIPTION
Theme mods (CSS only):
- Nocturne: Deep purple/midnight blue dark theme
- Sunrise: Warm golden light theme
- Ocean Breeze: Cool blue-green dark theme

Feature mods (CSS + JS with hook registration):
- Word Counter: Live word/char count badges on cards
- Quick Note: Floating FAB button for instant card creation
- Card Timestamps: Human-readable created/updated dates on cards

App mods (CSS + JS + overrides):
- Focus Mode: Minimal writing experience, hides navigation
- Research Hub: Rebrands app, adds research stats bar
- Minimal Writer: Distraction-free serif writing mode

All mods use CardSpoke_MODS.register(), implement onDisable for clean teardown, and pass full package validation. 235/235 tests pass.

https://claude.ai/code/session_01MJcRQYpTegM91eU9ACHUgt