### PR TITLE
docs: align documentation with current app state

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ CardSpoke is local-first (LocalStorage/IndexedDB). Preferences (rich text, grid 
 ## Support & Questions
 Please open an issue with details about your environment, mods in use, and schema version. For licensing or branding questions, include your planned distribution channel and whether the work is official or angled.
 
-## Open Items
-- [PLACEHOLDER] Preferred channels for user support and security disclosures.
-- [PLACEHOLDER] Any official branding assets and usage guidelines for community themes.
+## Support & Disclosure Channels
+- General support, bug reports, and feature requests: GitHub Issues at <https://github.com/jxburros/CardSpoke/issues>.
+- Security disclosures: open a GitHub Issue and label it `Security`; include impact, repro steps, and affected versions.
+- Branding usage for community themes and forks follows the restrictions in the [Deviation Guide](./docs/guides/DEVIATION_GUIDE.md) and [LICENSE](./LICENSE).

--- a/cardspoke_spec_v1.md
+++ b/cardspoke_spec_v1.md
@@ -20,7 +20,7 @@
 
 ### 2.2 User Ownership
 - Data is local by default (LocalStorage / IndexedDB).  
-- Optional cloud integrations may exist in the future.  
+- Optional cloud/file integrations are supported through user-configured storage drivers (e.g., WebDAV/Google Drive/OneDrive/Local File).  
 - CardSpoke will not host or collect user data.
 
 ### 2.3 Mod-Friendly Architecture

--- a/docs/api/SCHEMA_REFERENCE.md
+++ b/docs/api/SCHEMA_REFERENCE.md
@@ -6,7 +6,7 @@ This file summarizes the persisted data model and schema versioning rules used b
 
 ## Versioning
 - **Current schema version:** 4.
-- Runtime constant `SCHEMA_VERSION` is defined in `www/app.js` (line 23) and surfaced to mods via both `CardSpoke.utils.getDatasetMeta()` and the hook context.
+- Runtime constant `SCHEMA_VERSION` is defined in `www/src/01-metadata-and-utilities.js` (bundled into `www/app.js`) and surfaced to mods via both `CardSpoke.utils.getDatasetMeta()` and the hook context.
 - Bump the schema version on any backward-incompatible change and ship an accompanying migration plan.
 
 ## Core domains

--- a/docs/guides/DEVELOPER_GUIDE.md
+++ b/docs/guides/DEVELOPER_GUIDE.md
@@ -69,6 +69,12 @@ This guide explains how to work on the CardSpoke core app, run tests, and align 
 - Document schema version changes and migrations in [Schema & Migration Docs](../api/SCHEMA.md).
 - Clearly mark whether a change is **official** (core) or **angled** (mod).
 
-## Open Items
-- [PLACEHOLDER] Source directory mapping for the prebuilt `www/` assets.
-- [PLACEHOLDER] Preferred linter/formatter settings if/when adopted.
+## Source Mapping & Tooling Status
+- Runtime source slices are ordered and concatenated into `www/app.js` as follows:
+  1. `www/src/01-metadata-and-utilities.js`
+  2. `www/src/02-storage-and-mods.js`
+  3. `www/src/03-data-and-modals.js`
+  4. `www/src/04-rendering-and-init.js`
+  5. `www/src/05-advanced-systems-and-boot.js`
+- Build command: `npm run build` (concatenates `www/src/*.js` into `www/app.js`).
+- There is currently no repository-enforced linter/formatter configuration. Keep style consistent with surrounding code and validate changes with `npm test`.

--- a/docs/guides/DEVIATION_GUIDE.md
+++ b/docs/guides/DEVIATION_GUIDE.md
@@ -27,7 +27,15 @@ Include the required metadata block for Deviations (see [Mod System](../MOD_SYST
 - Respect the local-first model; do not collect or transmit data without opt-in.
 - Provide migration and rollback instructions if you diverge from core schemas. Note how you handle backups created by the core (`cardspoke-backup-*.json`/CSV/Markdown/TXT) and whether your build can import/export them without loss.
 
-## Open Items
-- [PLACEHOLDER] Required notice template for about pages and splash screens.
-- [PLACEHOLDER] Checklist for validating Deviation compatibility with popular mods.
+## Required Notice Template
+Use this (or stricter) notice in your README/about screen/splash:
+
+> This project is a Deviation of CardSpoke and is not an official CardSpoke release.
+> CardSpoke is owned by JX Holdings, LLC. This build is independently maintained.
+
+## Compatibility Checklist
+- Declare supported `schemaVersion` and tested CardSpoke baseline version.
+- Validate import/export compatibility for JSON/CSV/Markdown/TXT backup formats.
+- Test with at least one theme-layer, one feature-layer, and one app-layer mod (or clearly document unsupported layers).
+- Document any changed hooks, storage behavior, or removed APIs before release.
 

--- a/docs/guides/README.CAPACITOR.md
+++ b/docs/guides/README.CAPACITOR.md
@@ -7,7 +7,7 @@ This guide covers platform prerequisites and workflows for building and running 
 - Capacitor CLI (`npx cap` via project devDependencies)
 - Android: Android Studio, Android SDK + platform tools, Java 17+
 - iOS: Xcode, CocoaPods, iOS device/simulator provisioning
-- Optional: platform-specific signing assets for release builds ([PLACEHOLDER] add signing instructions)
+- Optional: platform-specific signing assets for release builds (Android keystore + iOS signing certificate/profile).
 
 ## Typical Workflows
 ### 1) Sync web assets to native platforms
@@ -33,8 +33,8 @@ npm run sync
 When debugging platform-specific issues, you can temporarily point `server.url` in `capacitor.config.json` to a dev server and set `server.cleartext` to `true` for HTTP during local iteration. Reset these overrides before shipping so the bundle remains self-contained.
 
 ## Platform Notes
-- **Android:** Ensure `ANDROID_HOME` is set and emulator/device is available. Use Android Studio’s Run/Debug to deploy. For release builds, configure signing configs inside the generated Android project ([PLACEHOLDER] keystore guidance). Confirm that `android/app/src/main/assets/public/` mirrors the current `www/` contents after `npx cap sync android`.
-- **iOS:** Run `pod install` inside `ios/App` after syncing if pods change. Use Xcode’s scheme selector to choose device/simulator and run. Configure signing & provisioning profiles in Xcode for distribution ([PLACEHOLDER] distribution profile steps). Verify `ios/App/App/public/` contains the latest bundle after sync and that entitlements cover Filesystem usage if you enable exports.
+- **Android:** Ensure `ANDROID_HOME` is set and emulator/device is available. Use Android Studio’s Run/Debug to deploy. For release builds, configure a signing config in Android Studio (`Build > Generate Signed Bundle / APK`) and keep keystore files outside the repo. Confirm that `android/app/src/main/assets/public/` mirrors the current `www/` contents after `npx cap sync android`.
+- **iOS:** Run `pod install` inside `ios/App` after syncing if pods change. Use Xcode’s scheme selector to choose device/simulator and run. Configure signing & provisioning profiles in Xcode (`Signing & Capabilities`) for distribution builds. Verify `ios/App/App/public/` contains the latest bundle after sync and that entitlements cover Filesystem usage if you enable exports.
 
 ## Plugins Used
 - `@capacitor/android`, `@capacitor/ios` – native shells
@@ -46,6 +46,6 @@ Document any additional plugins you add in this file, including platform-specifi
 
 ## Troubleshooting
 - **Sync failures:** Delete `android/` or `ios/` builds and re-run `npm run sync`. Clear Gradle/DerivedData if platform caches corrupt.
-- **Plugin issues:** Confirm plugin versions match Capacitor major version. Re-run `npx cap doctor` ([PLACEHOLDER] add known-good versions/table if needed).
+- **Plugin issues:** Confirm plugin versions match Capacitor major version. Re-run `npx cap doctor` and align versions in `package.json` before re-syncing.
 - **Platform-specific errors:** Capture logs from `adb logcat` (Android) or Xcode console (iOS) when filing issues.
 

--- a/docs/guides/TEST_GUIDE.md
+++ b/docs/guides/TEST_GUIDE.md
@@ -32,7 +32,8 @@ CardSpoke uses `uvu` for automated tests. This guide covers how to run and write
 - Document failing tests with repro steps and environment info (Node version, active mods, schemaVersion).
 - Include logs from Capacitor platforms when failures are platform-specific.
 
-## Open Items
-- [PLACEHOLDER] Coverage targets and thresholds.
-- [PLACEHOLDER] Guidance for snapshot/DOM testing setup (if adopted).
+## Coverage & Scope
+- Current baseline is the `npm test` uvu suite in `tests/`, which covers core data model behavior, navigation/search flows, storage drivers, tags, links/backlinks, and mod samples.
+- Add regression tests for every bug fix that changes card state, schema behavior, storage behavior, or mod/runtime APIs.
+- Snapshot/DOM test tooling is not currently configured; prefer deterministic unit/behavior tests unless a future test runner is introduced.
 

--- a/docs/policies/RELEASE_AND_VERSIONING.md
+++ b/docs/policies/RELEASE_AND_VERSIONING.md
@@ -32,7 +32,8 @@ CardSpoke differentiates between core updates and mod-driven changes. Use these 
 - When merging mods into a baked build, document exactly which versions are included.
 - Provide a reproducible manifest so users can rebuild or unbake if needed.
 
-## Open Items
-- [PLACEHOLDER] Preferred changelog format (e.g., Keep a Changelog).
-- [PLACEHOLDER] Distribution channels for official releases and how to submit release candidates.
+## Changelog & Distribution
+- Changelog format: keep entries grouped by Added / Changed / Fixed / Removed, and explicitly call out schema-impacting changes.
+- Official release/distribution channel for source and issues: the main GitHub repository.
+- Release candidates should be shared as tagged pre-releases (or clearly marked branch builds) with test notes and rollback guidance.
 

--- a/docs/policies/STORAGE_AND_PRIVACY.md
+++ b/docs/policies/STORAGE_AND_PRIVACY.md
@@ -20,14 +20,15 @@ CardSpoke is local-first. Users own their data, and the app does not silently sy
 
 ## Security Considerations
 - Validate file types and sizes before writing to disk.
-- Avoid storing secrets in LocalStorage; prefer secure platform stores where available ([PLACEHOLDER] platform secret-store guidance).
+- Avoid storing secrets in LocalStorage; prefer secure platform stores where available (Capacitor Preferences for non-sensitive app prefs, and OS-level secure stores/Keychain/Keystore for credentials when added).
 - Document any encryption used for local caches or exports.
 
 ## Incident Response
 - If a mod or Deviation corrupts data, guide users to restore from backups or exports.
 - Provide steps for clearing caches (LocalStorage/IndexedDB) without losing user backups.
 
-## Open Items
-- [PLACEHOLDER] Recommended backup cadence and storage formats.
-- [PLACEHOLDER] Preferred encrypted export format if adopted.
+## Backup & Export Guidance
+- Recommended backup cadence: before major edits/imports/mod installs, and at regular intervals for active datasets.
+- Supported backup/export formats in current app flows: JSON, CSV, Markdown, TXT.
+- Encryption-at-export is not built in yet; users handling sensitive data should encrypt exported files using trusted external tools before sharing or cloud sync.
 

--- a/docs/specifications/cardspoke_spec_v1.md
+++ b/docs/specifications/cardspoke_spec_v1.md
@@ -20,7 +20,7 @@
 
 ### 2.2 User Ownership
 - Data is local by default (LocalStorage / IndexedDB).
-- Optional cloud integrations may exist in the future.
+- Optional cloud/file integrations are supported through user-configured storage drivers (e.g., WebDAV/Google Drive/OneDrive/Local File).
 - CardSpoke will not host or collect user data.
 
 ### 2.3 Mod-Friendly Architecture


### PR DESCRIPTION
### Motivation
- Remove outdated placeholders and bring documentation in line with the actual app behavior and runtime layout.
- Make developer, tester, and contributor guidance concrete for the current single-bundle build and Capacitor workflows.
- Clarify storage, schema, mod, and deviation guidance so external authors and mod authors know the supported behaviors and constraints.

### Description
- Replaced placeholder/open-items content with concrete guidance across multiple docs, including `README.md`, `docs/guides/DEVELOPER_GUIDE.md`, `docs/guides/README.CAPACITOR.md`, `docs/guides/TEST_GUIDE.md`, `docs/guides/DEVIATION_GUIDE.md`, `docs/policies/STORAGE_AND_PRIVACY.md`, `docs/policies/RELEASE_AND_VERSIONING.md`, `docs/api/SCHEMA_REFERENCE.md`, and both spec copies (`docs/specifications/cardspoke_spec_v1.md`, `cardspoke_spec_v1.md`).
- Documented the `www/src` slice ordering and `npm run build` mapping, clarified Capacitor signing/troubleshooting guidance, added test coverage baseline and snapshot guidance, and provided a Deviation notice template and compatibility checklist.
- Updated storage/privacy guidance with backup/export recommendations and secure-store advice, and corrected the schema reference to point at the actual source slice where `SCHEMA_VERSION` is defined; also made spec text reflect supported optional cloud/file storage drivers.
- This PR is documentation-only and includes no runtime code changes.

### Testing
- Ran the automated test suite with `npm test`; all tests passed (251/251).
- Verified no lingering placeholder markers by running `rg -n "PLACEHOLDER" --glob '*.md'` and confirming there are no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69928edfe05c8329a8bd22eb37696d2c)