### PR TITLE
docs: synchronize documentation with current runtime behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ CardSpoke features a modern, extensible plugin system with three architectural l
 - **Feature Layer:** CSS and JavaScript; adds new features using the Plugin API. Medium risk.
 - **App Layer:** Full capabilities including core overrides, custom storage drivers, and app rebranding. High risk.
 
-### Modern Architecture (v0.17.0+)
+### Modern Architecture (current v0.17.0 runtime)
 
 The plugin system includes:
 

--- a/docs/api/API_REFERENCE.md
+++ b/docs/api/API_REFERENCE.md
@@ -44,7 +44,7 @@ window.CardSpoke.Plugin.register('plugin-id', {
 - **`list()`**: Returns an array of all registered plugin instances.
 - **`enable(id)`**: Enables a plugin by checking permissions, applying CSS, and running the setup function. Throws an error if permissions are not granted or if setup fails.
 - **`disable(id)`**: Disables a plugin by running teardown, removing CSS, and cleaning up resources.
-- **`install(pkg)`**: Installs a plugin package, registers it with a unique ID, and auto-enables based on risk assessment (SAFE and LOW risk plugins are enabled automatically). Persists to store. Returns the generated plugin ID.
+- **`install(pkg)`**: Installs a plugin package, registers it by manifest/base ID, and auto-enables based on risk assessment (SAFE and LOW risk plugins are enabled automatically). If an ID already exists, the prior plugin is disabled/unregistered and replaced. Persists to store and returns the installed plugin ID.
 - **`assessModRisk(pkg)`**: Assesses the risk level of a plugin package based on layer, capabilities, and permissions. Returns one of: `'SAFE'`, `'LOW'`, `'MEDIUM'`, `'HIGH'`.
   - `SAFE`: Theme layer with CSS only, no JavaScript
   - `LOW`: Feature layer with JavaScript, no core overrides
@@ -60,7 +60,9 @@ The context object passed to setup and teardown functions contains:
 - **`ctx.modId`**: The ID of the current plugin
 - **`ctx.appVersion`**: Current app version (0.17.0)
 - **`ctx.schemaVersion`**: Current schema version (4)
-- **`ctx.api`**: API object with `ui`, `data`, `storage`, and `events` namespaces
+- **`ctx.api`**: API object with `ui`, `data`, `storage`, `events`, `network`, and `filesystem` namespaces
+- **`ctx.config`**: Optional manifest config object (present when `manifest.config` is provided).
+- **`ctx.utils`**: Shared utility helper surface from `window.CardSpoke.utils` when available.
 - **`ctx.logger`**: Plugin-scoped logger with methods: `log()`, `info()`, `warn()`, `error()`
 
 ### Plugin API (ctx.api)
@@ -89,7 +91,7 @@ The context object passed to setup and teardown functions contains:
 
 #### Storage API (ctx.api.storage)
 
-The storage API provides plugin-namespaced storage using localStorage:
+The storage API provides plugin-namespaced storage using the active storage driver when available, with localStorage fallback:
 
 - **`get(key)`**: Retrieves a value from storage. The key is automatically namespaced to the plugin. Returns the stored value or null.
 - **`set(key, value)`**: Stores a value. The key is automatically namespaced to the plugin. Value is JSON serialized.
@@ -105,7 +107,16 @@ The events API provides an event bus for inter-plugin communication. Note: This 
 - **`off(eventName, callback)`**: Unsubscribes from an event.
 - **`emit(eventName, ...args)`**: Emits an event with optional arguments (variadic).
 - **`once(eventName, callback)`**: Subscribes to an event that fires only once.
-- **`clear(eventName)`**: Clears all listeners for the specified event (or all events if no name provided).
+
+#### Network API (ctx.api.network)
+
+- **`fetch(url, options)`**: Wraps `window.fetch` and enforces the `network` permission.
+- **`xhr()`**: Returns an `XMLHttpRequest` instance and enforces the `network` permission.
+
+#### Filesystem API (ctx.api.filesystem)
+
+- **`readFile(path, options)`**: Reads files via Capacitor Filesystem when available; requires `filesystem` permission.
+- **`writeFile(path, data, options)`**: Writes files via Capacitor Filesystem when available; requires `filesystem` permission.
 
 ### Resource Management
 
@@ -121,7 +132,7 @@ Plugins must declare required permissions in their manifest:
 
 - **`ui-override`**: Permission to inject or replace DOM elements
 - **`storage`**: Permission to access localStorage (plugin-namespaced)
-- **`network`**: Permission to make network requests (not enforced by core, but declared for transparency)
+- **`network`**: Permission to make network requests (`ctx.api.network.fetch` / `ctx.api.network.xhr`)
 - **`filesystem`**: Permission to access filesystem APIs (mobile only)
 - **`core-override`**: Permission to override core functionality (high risk)
 
@@ -193,4 +204,4 @@ Direct window functions for appearance:
 - Most utility functions work with the global `window.store` object
 - Plugins should prefer using `ctx.api.data` methods over direct window functions for better compatibility
 - Functions may return `undefined`, `null`, or empty arrays when data is not available
-- The app uses localStorage for preferences and datasets, IndexedDB is planned for future versions
+- The app uses localStorage plus pluggable storage drivers (including IndexedDB/local-file strategies) for datasets and plugin data

--- a/docs/api/PLUGIN_API.md
+++ b/docs/api/PLUGIN_API.md
@@ -49,8 +49,12 @@ Every plugin receives a context object:
     ui: UIApi,                // UI manipulation
     data: DataApi,            // Data access
     storage: StorageApi,      // Persistent storage
-    events: EventApi          // Event system
+    events: EventApi,         // Shared cross-plugin event bus
+    network: NetworkApi,       // Permission-gated network access
+    filesystem: FilesystemApi  // Permission-gated Capacitor filesystem access
   },
+  utils: object,              // CardSpoke shared utility surface
+  config?: object,            // Plugin manifest config (when provided)
   logger: Logger              // Scoped logger
 }
 ```
@@ -410,3 +414,15 @@ When a plugin is disabled, all resources are automatically cleaned up.
 - [Middleware Pipeline](./MIDDLEWARE_PIPELINE.md) - Intercept operations
 - [Component Registry](./COMPONENT_REGISTRY.md) - UI components
 - [Plugin System Documentation](../PLUGIN_SYSTEM.md) - Complete plugin system guide including permissions
+
+
+### Network API
+
+- `ctx.api.network.fetch(url, options)` wraps `window.fetch` and requires the `network` permission.
+- `ctx.api.network.xhr()` creates an `XMLHttpRequest` and requires the `network` permission.
+
+### Filesystem API
+
+- `ctx.api.filesystem.readFile(path, options)` reads files through Capacitor Filesystem when available.
+- `ctx.api.filesystem.writeFile(path, data, options)` writes files through Capacitor Filesystem when available.
+- Both filesystem calls require the `filesystem` permission and throw if Filesystem is unavailable on the current platform.

--- a/docs/guides/CODE_AND_PLUGIN_SYSTEM_HANDBOOK.md
+++ b/docs/guides/CODE_AND_PLUGIN_SYSTEM_HANDBOOK.md
@@ -10,7 +10,7 @@ It is intentionally specific: you’ll find concrete field names, hook signature
 
 CardSpoke’s runtime is a **single browser bundle** (`www/app.js`) produced by concatenating source slices in lexical order:
 
-1. `www/src/00-core-systems.js` **(NEW in v0.16.0)**
+1. `www/src/00-core-systems.js` (core runtime bootstrap)
 2. `www/src/01-metadata-and-utilities.js`
 3. `www/src/02-storage-and-plugins.js`
 4. `www/src/03-data-and-modals.js`
@@ -29,7 +29,7 @@ The bundle is designed to work in `file://` contexts, so many helpers are intent
 
 ## 2) Source Slice Responsibilities (Concrete)
 
-## `00-core-systems.js` **(NEW in v0.16.0)**
+## `00-core-systems.js`
 
 Initializes the modern plugin architecture before any other code runs:
 
@@ -55,7 +55,6 @@ Initializes the modern plugin architecture before any other code runs:
   - `disable(id)` - Disable plugin and run teardown
   - `get(id)` - Get plugin instance
   - `list()` - List all plugins
-  - `isEnabled(id)` - Check plugin status
   - Context APIs: `ctx.api.ui`, `ctx.api.data`, `ctx.api.storage`, `ctx.api.events`
   - Resource tracking and automatic cleanup
 

--- a/docs/guides/DEVELOPER_GUIDE.md
+++ b/docs/guides/DEVELOPER_GUIDE.md
@@ -26,7 +26,7 @@ This guide explains how to work on the CardSpoke core app, run tests, and align 
   - `index.html` - Entry point with modal structures and script loading
   - `capacitor.js` - Capacitor runtime bridge
   - `modules/` - Reference ES module versions (not used at runtime)
-- `tests/` - uvu test suites (284 passing tests out of 301 total across 18 files)
+- `tests/` - uvu test suites (26 files; currently 336 passing tests via `npm test`)
 - `docs/` - Project documentation organized by category
 - `capacitor.config.json` - Platform configuration for Capacitor
 

--- a/docs/policies/SECURITY_AND_SAFETY.md
+++ b/docs/policies/SECURITY_AND_SAFETY.md
@@ -71,7 +71,7 @@ This guide outlines expectations for secure, transparent, and user-respecting be
 - [ ] Use certificate pinning for API endpoints
 
 ## Static Analysis & Code Quality
-- Testing: `npm test` runs 227+ tests using uvu framework
+- Testing: `npm test` currently runs 336 uvu tests across 26 test files
 - Linting: Consider adding ESLint for code quality
 - Security scanning: Run `npm audit` before each release
 - Code review: All plugins should be reviewed before publication

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,210 +1,39 @@
 # CardSpoke Test Suite
 
-This directory contains automated tests for CardSpoke's core functionality.
+This directory contains the project's automated uvu suites for core behavior, plugin runtime systems, and regression coverage.
 
 ## Running Tests
 
 ```bash
-# Run all tests
+# Run all test files under tests/
 npm test
 
-# Run tests in watch mode
+# Re-run automatically while editing
 npm run test:watch
 ```
 
-## Test Framework
+## Current Suite Status
 
-We use [uvu](https://github.com/lukeed/uvu) - a minimal, fast test runner for Node.js.
+- Framework: [uvu](https://github.com/lukeed/uvu)
+- Test files: 26 (`*.test.js`)
+- Latest baseline: **336 / 336 passing** (`npm test`)
 
-## Test Files
+## What's Covered
 
-### `helpers.js`
-Test utilities and mock implementations:
-- `MockLocalStorage` - localStorage mock for testing
-- `createTestCard()` - Create test card objects
-- `createTestStore()` - Create test store objects
-- Core functions extracted for testing (search, bookmarks, etc.)
+- Core card CRUD, links/backlinks, hierarchy, and navigation flows
+- Search (single dataset + multi-dataset), tags, and UI state persistence
+- App initialization, menu/footer handlers, semantic selector expectations
+- Plugin runtime systems (validator, API contexts, middleware pipeline, component registry, permissions, phase 2/3 features)
+- Local file and storage-related behavior in the test harness
 
-### `backlinks-related.test.js`
-Tests for backlinks and related cards features:
-- Backlink detection and mapping
-- Related cards by shared tags
-- Bidirectional navigation
-- Connection relationship tracking
-- Edge cases for link resolution
+## Layout
 
-**Tests:** 25
-
-### `card-links.test.js`
-Tests for internal card linking:
-- Card link parsing and detection
-- Link token rendering
-- Navigation through links
-- Missing link handling
-
-**Tests:** 20
-
-### `tags-api.test.js`
-Tests for tag management system:
-- Getting, adding, and removing tags
-- Tag normalization and deduplication
-- Setting multiple tags at once
-- Getting all unique tags
-
-**Tests:** 19
-
-### `search-navigation.test.js`
-Tests for search and navigation features:
-- Searching by title, body, and tags
-- Case-insensitive search
-- Bookmark management
-- Recent cards tracking
-
-**Tests:** 15
-
-### `card-lookup.test.js`
-Tests for card lookup and search:
-- Finding cards by name
-- Normalized name matching
-- Case-insensitive search
-
-**Tests:** 14
-
-### `navigator-suite.test.js`
-Tests for navigation features:
-- Bookmarks management
-- Recent cards tracking
-- Navigation history
-
-**Tests:** 14
-
-### `store-structure.test.js`
-Tests for data store integrity:
-- Store structure validation
-- Card count management
-- RootOrder integrity
-- View mode toggling
-- Complex hierarchy handling
-- MockLocalStorage functionality
-
-**Tests:** 12
-
-### `ui-state.test.js`
-Tests for UI state management:
-- View mode toggling
-- State persistence
-- UI state updates
-
-**Tests:** 11
-
-### `multi-dataset-search.test.js`
-Tests for multi-dataset search functionality:
-- Search across current dataset
-- Search across all datasets
-- Dataset metadata handling
-- Result sorting and limiting
-- Performance optimization
-
-**Tests:** 10
-
-### `card-operations.test.js`
-Tests for card CRUD operations:
-- Creating cards
-- Adding cards to store
-- Deleting cards
-- Card hierarchy management
-- Recursive deletion
-
-**Tests:** 10
-
-### `version-validation.test.js`
-Tests for version management:
-- Version format validation
-- Schema version checks
-
-
-## Coverage
-
-Current test coverage focuses on:
-- ✅ Backlinks and related cards
-- ✅ Card linking and internal navigation
-- ✅ Tags API and tag management
-- ✅ Multi-dataset search
-- ✅ Card creation and deletion
-- ✅ Hierarchical relationships
-- ✅ Search functionality
-- ✅ Bookmarks and recent cards
-- ✅ Store integrity
-- ✅ MockLocalStorage
-- ✅ Version validation
-
-Not yet covered:
-- ❌ Import/Export operations (partial)
-- ❌ Plugin system hooks
-- ❌ UI rendering
-- ❌ Capacitor integrations
-- ❌ Plugin system hooks
-- ❌ UI rendering
-- ❌ Capacitor integrations
+- `helpers.js` — shared mocks and test utility functions
+- `*.test.js` — feature-focused suites (one domain per file)
 
 ## Adding New Tests
 
-1. Create a new test file in this directory (e.g., `feature-name.test.js`)
-2. Import test utilities from `helpers.js`
-3. Write tests using the uvu API:
-
-```javascript
-const { test } = require('uvu');
-const assert = require('uvu/assert');
-
-test('my feature works', () => {
-  assert.is(1 + 1, 2);
-});
-
-test.run();
-```
-
-## Best Practices
-
-- **Keep tests focused**: Each test should verify one specific behavior
-- **Use descriptive names**: Test names should clearly state what they verify
-- **Clean up after tests**: Ensure tests don't leave state behind
-- **Test edge cases**: Include tests for empty inputs, invalid data, etc.
-- **Keep tests fast**: Mock external dependencies (localStorage, DOM, etc.)
-
-## Continuous Integration
-
-Tests run automatically on every commit via GitHub Actions (when configured).
-
----
-
-**Last Updated:** 2025-11-30  
-**Test Count:** 188 tests
-
-## Required Files for Testing
-
-To run the test suite, you need:
-
-### Essential Files
-- `tests/helpers.js` - Test utilities and mock implementations
-- `tests/*.test.js` - Test files (all files ending in .test.js)
-- `package.json` - Contains test script configuration
-- `node_modules/` - Dependencies (uvu test framework)
-
-### Installation
-```bash
-# From repository root
-npm install    # Installs uvu and other dev dependencies
-```
-
-### Files NOT Required
-The test suite does NOT require:
-- `www/` directory (tests use extracted logic from helpers.js)
-- Browser environment (tests run in Node.js)
-- Capacitor dependencies
-- Native build tools
-
-### Test-Only Dependencies
-- `uvu` - Test framework (installed via `npm install`)
-
-The test suite is designed to be lightweight and run without the full application stack, focusing on pure data logic testing.
+1. Add a new `*.test.js` file in `tests/`.
+2. Import `test`/`assert` from `uvu` and any helpers from `./helpers.js`.
+3. Keep each case focused on one behavior and include edge conditions.
+4. Run `npm test` before submitting changes.


### PR DESCRIPTION
### Motivation
- Bring documentation into alignment with the code that ships in `www/src` and the runtime behavior observed in tests to avoid confusing or stale guidance. 
- Clarify the Plugin API and runtime contract so plugin authors can rely on implemented surfaces (event bus, network/filesystem, storage-driver behavior, and plugin install semantics). 
- Update test-suite and developer guidance metadata to reflect the current baseline so contributors have accurate expectations for CI and local verification. 

### Description
- Updated top-level guidance in `README.md` to reflect the current runtime framing (`Modern Architecture (current v0.17.0 runtime)`) and remove ambiguous version-threshold wording. 
- Revised `docs/api/API_REFERENCE.md` to document actual `ctx` surfaces (`events`, `network`, `filesystem`, `storage` backed by active storage driver with localStorage fallback), correct `install(pkg)` semantics (replace existing ID), and remove an undocumented `events.clear()` claim. 
- Revised `docs/api/PLUGIN_API.md` to include `ctx.config`, `ctx.utils`, and explicit `ctx.api.network` / `ctx.api.filesystem` sections describing permission-gated network and Capacitor filesystem calls. 
- Cleaned handbook and guide language in `docs/guides/CODE_AND_PLUGIN_SYSTEM_HANDBOOK.md` and `docs/guides/DEVELOPER_GUIDE.md` (removed stale “NEW in v0.16.0” note and updated test-suite metrics), updated security guidance in `docs/policies/SECURITY_AND_SAFETY.md`, and replaced `tests/README.md` with a current snapshot of the suite layout and baseline. 

### Testing
- Ran the full automated test suite with `npm test`, producing a green baseline of `336 / 336` passing uvu tests. 
- All documentation edits are textual and do not change runtime logic covered by the test suite, and the tests remained fully passing after the updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b857c5cfe48329b8605deaead008e9)