### PR TITLE
Replace literal UI glyphs with HTML entities and add script loader with bundle fallback

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -42,7 +42,7 @@
       <button class="header-btn" id="themeToggle" title="Toggle dark mode" aria-label="Toggle dark mode" data-plugin-anchor="btn-theme-toggle">
         <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
       </button>
-      <button class="header-btn" id="menuBtn" title="Open menu" aria-label="Open menu" data-plugin-anchor="btn-menu">☰</button>
+      <button class="header-btn" id="menuBtn" title="Open menu" aria-label="Open menu" data-plugin-anchor="btn-menu">&#9776;</button>
     </div>
   </header>
 
@@ -50,7 +50,7 @@
     <div class="menu-panel" data-plugin-anchor="menu-panel">
       <div class="menu-header">
         <div class="menu-title">Menu</div>
-        <button class="menu-close" id="menuClose" aria-label="Close menu">✕</button>
+        <button class="menu-close" id="menuClose" aria-label="Close menu">&#10005;</button>
       </div>
       
       <div class="menu-section">
@@ -114,7 +114,7 @@
       <div class="menu-section" id="menuDeveloperSection" style="display: none;">
         <div class="menu-section-title">Developer</div>
         <button class="menu-item" id="menuDeveloperConsole">
-          🔧 Developer Console
+          Developer Console
         </button>
       </div>
     </div>
@@ -143,7 +143,7 @@
         <option value="current">Current Dataset</option>
         <option value="all">All Datasets</option>
       </select>
-      <button class="search-clear" id="searchClear" aria-label="Clear search">✕</button>
+      <button class="search-clear" id="searchClear" aria-label="Clear search">&#10005;</button>
     </div>
   </div>
 
@@ -153,7 +153,7 @@
     <div class="modal">
       <div class="modal-header">
         <div class="modal-title">Upload Content</div>
-        <button class="modal-close" id="closeUploadModal" aria-label="Close upload modal">✕</button>
+        <button class="modal-close" id="closeUploadModal" aria-label="Close upload modal">&#10005;</button>
       </div>
       
       <div class="modal-tabs" role="tablist">
@@ -222,7 +222,28 @@
   <!-- Capacitor script - must be loaded before app scripts -->
   <script src="capacitor.js"></script>
 
-  <!-- Application entry point (Vite serves as ES modules in dev, bundles for prod) -->
-  <script type="module" src="/src/main.js"></script>
+  <!-- Application entry point loader: prefers ES modules, falls back to bundled app.js -->
+  <script>
+    (function() {
+      function loadBundle() {
+        var legacy = document.createElement('script');
+        legacy.src = './app.js';
+        legacy.defer = true;
+        document.body.appendChild(legacy);
+      }
+
+      // file:// and some embedded webviews cannot resolve module graphs reliably.
+      if (window.location.protocol === 'file:') {
+        loadBundle();
+        return;
+      }
+
+      var entry = document.createElement('script');
+      entry.type = 'module';
+      entry.src = './src/main.js';
+      entry.onerror = loadBundle;
+      document.body.appendChild(entry);
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Ensure consistent rendering of UI icons across platforms and embedded webviews by replacing literal Unicode glyphs with numeric HTML entities.
- Improve application startup reliability in environments that cannot resolve ES module graphs (such as `file:` protocol or certain webviews) by providing a fallback to a bundled entry script.

### Description
- Replaced literal glyphs in `www/index.html` for the menu button, close buttons, and search clear with numeric HTML entities (e.g. `&#9776;`, `&#10005;`).
- Removed the inline wrench emoji from the Developer Console menu label to avoid relying on emoji glyphs.
- Replaced the single module entry `<script type="module" src="/src/main.js"></script>` with an inline loader that attempts to load `./src/main.js` as a module and falls back to `./app.js` by appending a deferred script when module loading fails.
- Added special-case handling in the loader to immediately load the bundle when running under the `file:` protocol to avoid module resolution issues in file-based or embedded contexts.

### Testing
- Ran `npm run build` against the modified `www` assets and the build completed successfully.
- Ran the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d3f24d188329a587b1533e3933d7)