### PR TITLE
Load bundled app.js first to fix partial startup UI

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -222,27 +222,21 @@
   <!-- Capacitor script - must be loaded before app scripts -->
   <script src="capacitor.js"></script>
 
-  <!-- Application entry point loader: prefers ES modules, falls back to bundled app.js -->
+  <!-- Application entry point loader: prefers stable bundled app.js, falls back to ESM entry -->
   <script>
     (function() {
-      function loadBundle() {
-        var legacy = document.createElement('script');
-        legacy.src = './app.js';
-        legacy.defer = true;
-        document.body.appendChild(legacy);
+      function loadModuleEntry() {
+        var entry = document.createElement('script');
+        entry.type = 'module';
+        entry.src = './src/main.js';
+        document.body.appendChild(entry);
       }
 
-      // file:// and some embedded webviews cannot resolve module graphs reliably.
-      if (window.location.protocol === 'file:') {
-        loadBundle();
-        return;
-      }
-
-      var entry = document.createElement('script');
-      entry.type = 'module';
-      entry.src = './src/main.js';
-      entry.onerror = loadBundle;
-      document.body.appendChild(entry);
+      var bundle = document.createElement('script');
+      bundle.src = './app.js';
+      bundle.defer = true;
+      bundle.onerror = loadModuleEntry;
+      document.body.appendChild(bundle);
     })();
   </script>
 </body>


### PR DESCRIPTION
### Motivation
- The ESM entry path can fail to initialize the full app at runtime (leaving only header/footer interactive), so the startup loader should prefer the stable bundled runtime.

### Description
- Updated the startup loader in `www/index.html` to append a deferred `./app.js` bundle by default and use its `onerror` handler to fall back to the ESM entry `./src/main.js`, replacing the previous module-first logic.

### Testing
- Ran `npm run build` which completed successfully and produced the bundle.
- Ran `npm test` which surfaced unrelated version-validation failures in `tests/version-validation.test.js` (checks for an `APP_VERSION` constant in `app.js`); these failures appear to be pre-existing and not caused by this HTML loader change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2dad4b9288329837ab9facc192232)