### PR TITLE
Update import paths to use src directory structure

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -2208,7 +2208,7 @@ import {
   draggedCardId, setDraggedCardId,
   dragOverCardId, setDragOverCardId,
   undoStack, redoStack, trashBin
-} from './state.js';
+} from './src/state.js';
 
 // =============================================================
 // --- SELF-CONTAINED UTILITIES ---
@@ -2850,7 +2850,7 @@ import {
   navState, setNavState,
   navHistory, setNavHistory,
   instanceKey
-} from './state.js';
+} from './src/state.js';
 
 
       // Source Part 2/5: Storage drivers, navigation, and plugin runtime
@@ -4803,7 +4803,7 @@ import {
   store, setStore,
   instanceKey, setInstanceKey,
   trashBin
-} from './state.js';
+} from './src/state.js';
 
 
       // Source Part 3/5: Data CRUD, imports/exports, dataset modals
@@ -7277,7 +7277,7 @@ import {
   dirty, setDirty,
   searchResultsState, setSearchResultsState,
   trashBin
-} from './state.js';
+} from './src/state.js';
 
 
       // Source Part 4/5: Rendering, themes, footer, and initialization
@@ -8709,7 +8709,7 @@ import {
   undoStack, redoStack, trashBin,
   draggedCardId, setDraggedCardId,
   dragOverCardId, setDragOverCardId
-} from './state.js';
+} from './src/state.js';
 
 
       // Source Part 5/5: Advanced systems (undo/redo, tags, search) and boot


### PR DESCRIPTION
## Summary
Updated all import statements in `www/app.js` to reference the new `src/` directory structure for the state module, reflecting a reorganization of the project's file structure.

## Key Changes
- Updated 5 import statements across different sections of `www/app.js` to import from `./src/state.js` instead of `./state.js`
- Changes span across all major source parts of the application:
  - Part 1/5: State management and drag operations
  - Part 2/5: Storage drivers, navigation, and plugin runtime
  - Part 3/5: Data CRUD, imports/exports, and dataset modals
  - Part 4/5: Rendering, themes, footer, and initialization
  - Part 5/5: Advanced systems (undo/redo, tags, search) and boot

## Implementation Details
This is a straightforward path update to align with the new project structure where the `state.js` module has been moved into a `src/` subdirectory. All import statements maintain the same module exports and functionality; only the relative path has changed.

https://claude.ai/code/session_01HXP7J8cFkfSjP35QdZwZw4