### PR TITLE
Add custom Vite plugin to serve pre-built app.js bundle

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,7 @@
 
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
+import fs from 'fs';
 
 export default defineConfig({
   // Serve from www/ where index.html lives
@@ -60,7 +61,23 @@ export default defineConfig({
   },
 
   // Plugin configuration
-  plugins: [],
+  plugins: [
+    {
+      // app.js is a pre-built IIFE bundle whose srcdoc template literal
+      // contains raw HTML that confuses vite:import-analysis (es-module-lexer
+      // trips on the `<` characters as if they were JSX).  Serve it directly
+      // through the dev-server middleware so Vite never runs its transform
+      // pipeline on it.
+      name: 'serve-prebuilt-bundle',
+      configureServer(server) {
+        server.middlewares.use('/app.js', (_req, res) => {
+          const bundlePath = resolve(__dirname, 'www/app.js');
+          res.setHeader('Content-Type', 'application/javascript');
+          res.end(fs.readFileSync(bundlePath, 'utf-8'));
+        });
+      }
+    }
+  ],
 
   // Define global constants
   define: {


### PR DESCRIPTION
## Summary
Added a custom Vite plugin that serves the pre-built `app.js` bundle directly through the dev-server middleware, bypassing Vite's transform pipeline to prevent parsing errors.

## Key Changes
- Imported `fs` module for file reading operations
- Created a new `serve-prebuilt-bundle` Vite plugin that:
  - Intercepts requests to `/app.js`
  - Reads the pre-built bundle directly from disk
  - Serves it with the correct `application/javascript` content type
  - Bypasses Vite's import analysis and transform pipeline

## Implementation Details
The plugin was necessary because `app.js` is a pre-built IIFE bundle containing a `srcdoc` template literal with raw HTML. This HTML content includes `<` characters that confuse Vite's import analysis (specifically es-module-lexer), which incorrectly interprets them as JSX syntax. By serving the file directly through middleware, we avoid running Vite's transform pipeline on this file entirely.

https://claude.ai/code/session_0112fJjGwLb55LdHyNctesej