### PR TITLE
Make CardSpoke offline-first by default

### DIFF
--- a/docs/guides/OFFLINE_FIRST.md
+++ b/docs/guides/OFFLINE_FIRST.md
@@ -1,0 +1,97 @@
+# Offline-First CardSpoke Guide
+
+CardSpoke should feel the same online and offline except for features that explicitly require a remote service. The app is a local knowledge tool first; remote storage, sharing, and external integrations are add-ons.
+
+## Product Rule
+
+> Local card work must not depend on the network.
+
+Users must be able to create, edit, read, search, import, export, and navigate local datasets without an internet connection.
+
+## User Experience Contract
+
+| Situation | Expected behavior |
+| --- | --- |
+| Device is offline | Core app continues working normally. |
+| User edits a card offline | Change saves locally. |
+| Dataset has remote sync configured | UI shows local save succeeded and remote sync is pending. |
+| Remote sync fails | UI must not imply that the local save failed. |
+| Remote copy changed elsewhere | CardSpoke should ask the user to resolve the conflict. |
+| Remote-only feature is selected offline | Feature explains that it needs network access. |
+
+## Local Save vs Remote Sync
+
+Use separate mental models and UI language:
+
+- **Local save:** The user's working copy on this device.
+- **Remote sync:** Optional propagation to Google Drive, OneDrive, WebDAV, or another off-device target.
+
+The local save is authoritative while the user is editing. Remote targets should be treated as sync/export destinations rather than live dependencies for normal card operations.
+
+## Preferred Dataset Shape
+
+Future storage metadata should prefer local storage plus optional sync targets:
+
+```json
+{
+  "storageType": "indexeddb",
+  "syncTargets": [
+    {
+      "kind": "googledrive",
+      "status": "pending",
+      "lastSyncedAt": null,
+      "lastError": null
+    }
+  ]
+}
+```
+
+Avoid modeling a normal editable dataset as if it lives only in a cloud driver. If a user chooses Google Drive, OneDrive, or WebDAV, CardSpoke should still maintain a local working copy.
+
+## App Shell Caching
+
+The browser build includes a service worker for local app-shell assets. It should cache only files needed to load the app UI:
+
+- `index.html`
+- `styles.css`
+- `app-loader.js`
+- `offline-status.js`
+- `app.js`
+- `CardSpoke.svg`
+- `manifest.webmanifest`
+
+Do not place user datasets, exports, plugin secrets, credentials, or cloud payloads in service-worker Cache Storage.
+
+## Native Builds
+
+Capacitor builds already package the web bundle into the native shell. Offline-first behavior still depends on the same rule: local storage and local files are available without network, while off-device storage waits until connectivity returns.
+
+## Plugin Rules
+
+Plugins should declare when they need network access. Offline-safe plugins should continue running without internet. Online plugins should fail gracefully with clear language, not break the app shell or local dataset.
+
+Recommended permission names for future plugin manifests:
+
+- `network`
+- `remote-storage`
+- `external-api`
+- `ai-service`
+
+## Testing Expectations
+
+Offline-first changes should include at least static or automated checks for:
+
+1. A web manifest is linked from `www/index.html`.
+2. A service worker is registered from the app shell.
+3. The service worker caches only app-shell assets.
+4. Remote scripts are documented as optional online integrations.
+5. Save status language distinguishes local saves from remote sync.
+
+For browser QA, manually test:
+
+1. Load the app once online.
+2. Disable network.
+3. Reload the app.
+4. Create/edit/delete cards.
+5. Reload again and confirm local persistence.
+6. Re-enable network and confirm remote sync can resume if configured.

--- a/docs/policies/STORAGE_AND_PRIVACY.md
+++ b/docs/policies/STORAGE_AND_PRIVACY.md
@@ -1,12 +1,13 @@
 # Storage & Privacy Notes
 
-CardSpoke is local-first. Users own their data, and the app does not silently sync or host information.
+CardSpoke is local-first. Users own their data, and the app does not silently sync or host information. Offline use is a first-class experience, not a fallback mode.
 
 ## Storage Model
 
 - **LocalStorage:** Lightweight configuration, session data, and feature toggles. Also the default driver for structured card content, relationships, histories, and plugin registries — datasets are namespaced and tracked with metadata (name, card counts, recent/bookmark counts, schema/app version) so multiple vaults can coexist.
 - **IndexedDB:** An optional, per-dataset storage driver users can select instead of LocalStorage for card content and relationships. Also used internally for Local File System handle persistence, unrelated to card storage.
 - **Filesystem (via Capacitor Filesystem):** Optional for attachments or exports; only used when explicitly enabled.
+- **Off-device storage:** Google Drive, OneDrive, WebDAV, or future cloud targets are optional online integrations. They must never be required for normal card creation, editing, reading, navigation, import, export, or local dataset switching.
 
 ## Default Behavior
 
@@ -14,6 +15,15 @@ CardSpoke is local-first. Users own their data, and the app does not silently sy
 - No analytics or tracking beacons are built into the core.
 - Plugins must not transmit data off-device without explicit, informed consent.
 - Preferences stored under `cardspoke_*` keys (rich text, grid view, typography, high contrast, dev mode, active theme) stay on-device and are restored at startup.
+- Local saves are authoritative while the user edits. Remote sync may fail, be unavailable, or be pending without invalidating the local save.
+
+## Offline-First UX Rules
+
+- The app shell should load offline after it has been installed or visited in a service-worker-capable browser.
+- Offline status should only affect explicitly online features such as off-site storage, remote sync, remote plugin galleries, hosted sharing, or external API features.
+- Save messaging must distinguish local save failure from remote sync failure. If a local save succeeds and remote sync fails, the user should see that their local copy is safe.
+- Remote sync conflicts must be surfaced for review instead of silently overwriting local data.
+- Plugins that require network access should declare that need and degrade gracefully when offline.
 
 ## User Controls
 
@@ -26,6 +36,7 @@ CardSpoke is local-first. Users own their data, and the app does not silently sy
 - Validate file types and sizes before writing to disk.
 - Avoid storing secrets in LocalStorage; prefer secure platform stores where available (Capacitor Preferences for non-sensitive app prefs, and OS-level secure stores/Keychain/Keystore for credentials when added).
 - Document any encryption used for local caches or exports.
+- Do not cache user datasets in service-worker Cache Storage. Cache Storage should only hold app-shell assets such as HTML, CSS, JS, icons, and the manifest.
 
 ## Incident Response
 

--- a/tests/offline-first.test.js
+++ b/tests/offline-first.test.js
@@ -21,6 +21,8 @@ test('service worker caches app shell assets', () => {
   assert.ok(worker.includes('./styles.css'));
   assert.ok(worker.includes('./offline-status.js'));
   assert.ok(worker.includes('url.origin !== self.location.origin'));
+  assert.ok(worker.includes('response.status === 200'));
+  assert.ok(worker.includes("response.type === 'basic'"));
 });
 
 test('offline status separates local save from remote sync', () => {
@@ -28,6 +30,9 @@ test('offline status separates local save from remote sync', () => {
   assert.ok(status.includes('Saved locally'));
   assert.ok(status.includes('Sync pending'));
   assert.ok(status.includes('Local save failed'));
+  assert.ok(status.includes('cardspoke_dataset_metadata'));
+  assert.ok(status.includes("localStorage.getItem('activeInstance')"));
+  assert.ok(status.includes("indicator.textContent !== text"));
   assert.ok(status.includes('googledrive'));
   assert.ok(status.includes('onedrive'));
   assert.ok(status.includes('webdav'));

--- a/tests/offline-first.test.js
+++ b/tests/offline-first.test.js
@@ -1,0 +1,43 @@
+import { test } from 'uvu';
+import * as assert from 'uvu/assert';
+import { readFileSync } from 'node:fs';
+
+function read(path) {
+  return readFileSync(new URL('../' + path, import.meta.url), 'utf8');
+}
+
+test('web app declares an installable offline app shell', () => {
+  const index = read('www/index.html');
+  assert.ok(index.includes('rel="manifest" href="manifest.webmanifest"'));
+  assert.ok(index.includes('offline-status.js'));
+  assert.ok(index.includes('app-loader.js'));
+});
+
+test('service worker caches app shell assets', () => {
+  const worker = read('www/service-worker.js');
+  assert.ok(worker.includes('CACHE_VERSION'));
+  assert.ok(worker.includes('./index.html'));
+  assert.ok(worker.includes('./app.js'));
+  assert.ok(worker.includes('./styles.css'));
+  assert.ok(worker.includes('./offline-status.js'));
+  assert.ok(worker.includes('url.origin !== self.location.origin'));
+});
+
+test('offline status separates local save from remote sync', () => {
+  const status = read('www/offline-status.js');
+  assert.ok(status.includes('Saved locally'));
+  assert.ok(status.includes('Sync pending'));
+  assert.ok(status.includes('Local save failed'));
+  assert.ok(status.includes('googledrive'));
+  assert.ok(status.includes('onedrive'));
+  assert.ok(status.includes('webdav'));
+});
+
+test('storage policy requires offline-first behavior', () => {
+  const policy = read('docs/policies/STORAGE_AND_PRIVACY.md');
+  assert.ok(policy.includes('Offline use is a first-class experience'));
+  assert.ok(policy.includes('Local saves are authoritative'));
+  assert.ok(policy.includes('Remote sync may fail'));
+});
+
+test.run();

--- a/www/index.html
+++ b/www/index.html
@@ -6,24 +6,23 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="app:version" content="0.17.0">
   <meta name="app:author" content="jxburros">
+  <meta name="theme-color" content="#111111">
+  <link rel="manifest" href="manifest.webmanifest">
 
   <!-- Content Security Policy -->
   <meta http-equiv="Content-Security-Policy" content="
     default-src 'self';
     script-src 'self' 'unsafe-eval' https://accounts.google.com https://alcdn.msauth.net;
-    style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
-    font-src 'self' https://fonts.gstatic.com;
+    style-src 'self' 'unsafe-inline';
+    font-src 'self';
     connect-src 'self' https://www.googleapis.com https://graph.microsoft.com https://login.microsoftonline.com *;
     img-src 'self' data: blob: https:;
     frame-src https://accounts.google.com https://login.microsoftonline.com;
+    worker-src 'self';
     object-src 'none';
     base-uri 'self';
     form-action 'self';
   ">
-
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@900&family=Outfit:wght@400;700&display=swap" rel="stylesheet">
 
   <link rel="stylesheet" href="styles.css">
 </head>
@@ -215,12 +214,15 @@
     </div>
   </div>
 
-  <!-- Cloud Storage Libraries -->
+  <!-- Cloud Storage Libraries: optional online features only. Core editing must work without them. -->
   <script src="https://accounts.google.com/gsi/client" async defer></script>
   <script src="https://alcdn.msauth.net/browser/2.30.0/js/msal-browser.min.js"></script>
 
   <!-- Capacitor script - must be loaded before app scripts -->
   <script src="capacitor.js"></script>
+
+  <!-- Offline status and PWA registration. Keeps local save state separate from remote sync state. -->
+  <script src="offline-status.js"></script>
 
   <!-- Application entry point loader: prefers stable bundled app.js, falls back to ESM entry -->
   <script src="app-loader.js"></script>

--- a/www/manifest.webmanifest
+++ b/www/manifest.webmanifest
@@ -1,0 +1,19 @@
+{
+  "name": "CardSpoke",
+  "short_name": "CardSpoke",
+  "description": "A lightweight, local-first, card-based knowledge system.",
+  "start_url": "./index.html",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#111111",
+  "theme_color": "#111111",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "CardSpoke.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/www/offline-status.js
+++ b/www/offline-status.js
@@ -10,6 +10,11 @@
     pending: 'Saving locally...',
     error: 'Local save failed'
   };
+  var REMOTE_STORAGE_KINDS = {
+    googledrive: true,
+    onedrive: true,
+    webdav: true
+  };
 
   function isOnline() {
     return typeof navigator.onLine === 'boolean' ? navigator.onLine : true;
@@ -17,11 +22,27 @@
 
   function getRemoteStorageKind() {
     try {
-      var raw = localStorage.getItem('nested_cards_store');
+      var metaRaw = localStorage.getItem('cardspoke_dataset_metadata');
+      if (metaRaw) {
+        var metadata = JSON.parse(metaRaw);
+        var activeId = metadata && metadata.activeDatasetId;
+        var activeDataset = activeId && metadata.datasets && metadata.datasets[activeId];
+        var driver = activeDataset && activeDataset.storage && activeDataset.storage.driver;
+        if (REMOTE_STORAGE_KINDS[driver]) {
+          return driver;
+        }
+      }
+    } catch (_metadataError) {
+      // Fallback to direct store parsing if dataset metadata is unavailable.
+    }
+
+    try {
+      var activeKey = localStorage.getItem('activeInstance') || 'nested_cards_store';
+      var raw = localStorage.getItem(activeKey);
       if (!raw) return null;
       var parsed = JSON.parse(raw);
       var storageType = parsed && parsed.metadata && parsed.metadata.storageType;
-      if (storageType === 'googledrive' || storageType === 'onedrive' || storageType === 'webdav') {
+      if (REMOTE_STORAGE_KINDS[storageType]) {
         return storageType;
       }
     } catch (_err) {
@@ -33,8 +54,12 @@
   function setStatus(text, title) {
     var indicator = document.getElementById('saveStatus');
     if (!indicator) return;
-    indicator.textContent = text;
-    if (title) indicator.title = title;
+    if (indicator.textContent !== text) {
+      indicator.textContent = text;
+    }
+    if (typeof title === 'string' && indicator.title !== title) {
+      indicator.title = title;
+    }
   }
 
   function describeRemote(kind) {
@@ -77,16 +102,16 @@
     if (!indicator) return;
 
     var current = (indicator.textContent || '').trim();
-    if (current === 'Saved') {
+    if (current === 'Saved' || current === '✓') {
       var remoteKind = getRemoteStorageKind();
       if (!isOnline() && remoteKind) {
         setStatus('Saved locally · Sync pending', describeRemote(remoteKind) + ' will sync when this device is online.');
       } else {
         setStatus(LOCAL_SAVE_TEXT.saved, 'Saved on this device.');
       }
-    } else if (current === 'Saving…') {
+    } else if (current === 'Saving…' || current === 'Saving...' || current === '●') {
       setStatus(LOCAL_SAVE_TEXT.pending, 'Saving to this device.');
-    } else if (current === 'Save failed') {
+    } else if (current === 'Save failed' || current === '✕') {
       setStatus(LOCAL_SAVE_TEXT.error, 'CardSpoke could not save to this device.');
     }
   }

--- a/www/offline-status.js
+++ b/www/offline-status.js
@@ -1,0 +1,128 @@
+/*
+ * Offline status coordinator for CardSpoke.
+ *
+ * CardSpoke's core save path is local-first. This script keeps that visible to
+ * users by separating local save status from remote/off-device sync status.
+ */
+(function () {
+  var LOCAL_SAVE_TEXT = {
+    saved: 'Saved locally',
+    pending: 'Saving locally...',
+    error: 'Local save failed'
+  };
+
+  function isOnline() {
+    return typeof navigator.onLine === 'boolean' ? navigator.onLine : true;
+  }
+
+  function getRemoteStorageKind() {
+    try {
+      var raw = localStorage.getItem('nested_cards_store');
+      if (!raw) return null;
+      var parsed = JSON.parse(raw);
+      var storageType = parsed && parsed.metadata && parsed.metadata.storageType;
+      if (storageType === 'googledrive' || storageType === 'onedrive' || storageType === 'webdav') {
+        return storageType;
+      }
+    } catch (_err) {
+      // Encrypted/corrupt/unavailable stores should not break offline status.
+    }
+    return null;
+  }
+
+  function setStatus(text, title) {
+    var indicator = document.getElementById('saveStatus');
+    if (!indicator) return;
+    indicator.textContent = text;
+    if (title) indicator.title = title;
+  }
+
+  function describeRemote(kind) {
+    if (kind === 'googledrive') return 'Google Drive';
+    if (kind === 'onedrive') return 'OneDrive';
+    if (kind === 'webdav') return 'WebDAV';
+    return 'remote storage';
+  }
+
+  function refreshOfflineStatus() {
+    var indicator = document.getElementById('saveStatus');
+    if (!indicator) return;
+
+    var current = (indicator.textContent || '').trim();
+    var lower = current.toLowerCase();
+    var remoteKind = getRemoteStorageKind();
+    var online = isOnline();
+
+    if (!online && remoteKind) {
+      if (lower === 'saved' || lower === LOCAL_SAVE_TEXT.saved.toLowerCase() || lower === '') {
+        setStatus('Saved locally · Sync pending', describeRemote(remoteKind) + ' will sync when this device is online.');
+      }
+      return;
+    }
+
+    if (!online) {
+      if (lower === 'saved' || lower === LOCAL_SAVE_TEXT.saved.toLowerCase()) {
+        setStatus(LOCAL_SAVE_TEXT.saved, 'Saved on this device. CardSpoke does not need internet for local editing.');
+      }
+      return;
+    }
+
+    if (online && remoteKind && lower === 'saved locally · sync pending') {
+      setStatus('Saved locally · Sync ready', describeRemote(remoteKind) + ' sync can resume now that this device is online.');
+    }
+  }
+
+  function normalizeCoreSaveText() {
+    var indicator = document.getElementById('saveStatus');
+    if (!indicator) return;
+
+    var current = (indicator.textContent || '').trim();
+    if (current === 'Saved') {
+      var remoteKind = getRemoteStorageKind();
+      if (!isOnline() && remoteKind) {
+        setStatus('Saved locally · Sync pending', describeRemote(remoteKind) + ' will sync when this device is online.');
+      } else {
+        setStatus(LOCAL_SAVE_TEXT.saved, 'Saved on this device.');
+      }
+    } else if (current === 'Saving…') {
+      setStatus(LOCAL_SAVE_TEXT.pending, 'Saving to this device.');
+    } else if (current === 'Save failed') {
+      setStatus(LOCAL_SAVE_TEXT.error, 'CardSpoke could not save to this device.');
+    }
+  }
+
+  function watchSaveIndicator() {
+    var indicator = document.getElementById('saveStatus');
+    if (!indicator || typeof MutationObserver === 'undefined') return;
+
+    var observer = new MutationObserver(function () {
+      normalizeCoreSaveText();
+      refreshOfflineStatus();
+    });
+
+    observer.observe(indicator, { childList: true, characterData: true, subtree: true });
+    normalizeCoreSaveText();
+    refreshOfflineStatus();
+  }
+
+  function registerServiceWorker() {
+    var isNative = typeof window.Capacitor !== 'undefined' &&
+      typeof window.Capacitor.isNativePlatform === 'function' &&
+      window.Capacitor.isNativePlatform();
+
+    if (isNative) return;
+    if (!('serviceWorker' in navigator)) return;
+    if (location.protocol !== 'https:' && location.hostname !== 'localhost' && location.hostname !== '127.0.0.1') return;
+
+    navigator.serviceWorker.register('./service-worker.js').catch(function (error) {
+      console.warn('[CardSpoke Offline] Service worker registration failed:', error);
+    });
+  }
+
+  window.addEventListener('online', refreshOfflineStatus);
+  window.addEventListener('offline', refreshOfflineStatus);
+  window.addEventListener('DOMContentLoaded', function () {
+    registerServiceWorker();
+    watchSaveIndicator();
+  });
+})();

--- a/www/service-worker.js
+++ b/www/service-worker.js
@@ -1,0 +1,70 @@
+/*
+ * CardSpoke offline app shell.
+ *
+ * This cache is intentionally limited to local, versioned app-shell assets.
+ * User data remains in CardSpoke's local storage drivers and is never copied
+ * into Cache Storage by this worker.
+ */
+const CACHE_VERSION = 'cardspoke-app-shell-v0.17.0-offline-first-1';
+const APP_SHELL = [
+  './',
+  './index.html',
+  './styles.css',
+  './app-loader.js',
+  './offline-status.js',
+  './app.js',
+  './CardSpoke.svg',
+  './manifest.webmanifest'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_VERSION)
+      .then(cache => cache.addAll(APP_SHELL))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys()
+      .then(keys => Promise.all(
+        keys
+          .filter(key => key.startsWith('cardspoke-app-shell-') && key !== CACHE_VERSION)
+          .map(key => caches.delete(key))
+      ))
+      .then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const request = event.request;
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then(response => {
+          const copy = response.clone();
+          caches.open(CACHE_VERSION).then(cache => cache.put('./index.html', copy));
+          return response;
+        })
+        .catch(() => caches.match('./index.html'))
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request)
+      .then(cached => cached || fetch(request).then(response => {
+        const copy = response.clone();
+        caches.open(CACHE_VERSION).then(cache => cache.put(request, copy));
+        return response;
+      }))
+  );
+});

--- a/www/service-worker.js
+++ b/www/service-worker.js
@@ -50,8 +50,10 @@ self.addEventListener('fetch', event => {
     event.respondWith(
       fetch(request)
         .then(response => {
-          const copy = response.clone();
-          caches.open(CACHE_VERSION).then(cache => cache.put('./index.html', copy));
+          if (response && response.status === 200) {
+            const copy = response.clone();
+            caches.open(CACHE_VERSION).then(cache => cache.put('./index.html', copy));
+          }
           return response;
         })
         .catch(() => caches.match('./index.html'))
@@ -62,8 +64,10 @@ self.addEventListener('fetch', event => {
   event.respondWith(
     caches.match(request)
       .then(cached => cached || fetch(request).then(response => {
-        const copy = response.clone();
-        caches.open(CACHE_VERSION).then(cache => cache.put(request, copy));
+        if (response && response.status === 200 && response.type === 'basic') {
+          const copy = response.clone();
+          caches.open(CACHE_VERSION).then(cache => cache.put(request, copy));
+        }
         return response;
       }))
   );


### PR DESCRIPTION
## Summary

This PR implements the offline-first direction for CardSpoke with focused app-shell, status, documentation, and test changes.

## Changes

- Adds a PWA manifest.
- Adds a service worker for local app-shell assets.
- Adds an offline status coordinator that separates local save status from remote sync status.
- Removes remote font loading from the default app shell.
- Updates the storage and privacy policy.
- Adds an offline-first implementation guide.
- Adds regression tests for the offline app shell and status language.

## Notes

This does not rewrite the main storage engine. The existing storage flow is already local-first, so this PR hardens the browser shell and UX around that rule. A later PR can move cloud integrations into explicit sync target metadata with conflict handling.

## Testing

Added `tests/offline-first.test.js`. Please run `npm test` locally or in CI before merging.