### PR TITLE
Fix CardSpoke QA hygiene issues

### DIFF
--- a/.ai/qa.md
+++ b/.ai/qa.md
@@ -187,7 +187,6 @@ Run:
 npm run build
 ~~~
 
-
 Validate:
 
 - Vite build completes successfully.

--- a/.claude/skills/cardspoke-plugin-review/SKILL.md
+++ b/.claude/skills/cardspoke-plugin-review/SKILL.md
@@ -89,8 +89,8 @@ If a proposed fix changes runtime behavior rather than the plugin, check it
 against `docs/PLUGIN_INVARIANTS.md` first: the `window.CardSpoke` surface,
 boot order, host-bridge globals, `store.plugins` schema, permission names,
 middleware operation names, component names, and CSS selectors are contracts.
-Changing one means following that document's change checklist (docs + samples
-+ tests + version bump), not a quiet edit.
+Changing one means following that document's change checklist (documentation,
+samples, tests, and a version bump), not a quiet edit.
 
 ## Validation commands
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,14 +40,7 @@ jobs:
       - name: Dependency audit
         run: |
           npm audit --json > npm-audit-report.json || true
-          node -e '
-            const r = JSON.parse(require("fs").readFileSync("npm-audit-report.json", "utf8"));
-            const v = (r.metadata && r.metadata.vulnerabilities) || {};
-            const line = Object.entries(v).map(([k, n]) => `${k}: ${n}`).join(", ") || "none";
-            console.log("Vulnerabilities —", line);
-            require("fs").appendFileSync(process.env.GITHUB_STEP_SUMMARY || "/dev/null",
-              `### npm audit\n\nVulnerabilities — ${line}\n`);
-          '
+          node scripts/summarize-npm-audit.mjs npm-audit-report.json
           npm audit --audit-level=high
 
       - name: Upload dependency audit report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format follows Keep a Changelog and the project uses semantic versioning whe
 
 ---
 
+## [Unreleased]
+
+### Fixed
+
+- Removed the nonexistent Node package entry point from this browser-only package.
+- Moved dependency-audit summary generation into a checked-in Node script so the GitHub Pages workflow passes shell validation without changing the release gate.
+- Corrected the remaining markdownlint findings in the QA profile, plugin review skill, and historical audit report.
+
+---
+
 ## [0.20.0] – 2026-07-20
 
 ### Changed

--- a/docs/reports/AUDIT_QA_2026-07-10.md
+++ b/docs/reports/AUDIT_QA_2026-07-10.md
@@ -3,7 +3,7 @@
 **Date:** 2026-07-10  
 **Repository:** `jxburros/CardSpoke`  
 **Reviewed commit:** `034d323a36a64dcb0d8996b5ea9eb180b8bd2cd3` (`main`)  
-**Deployed application:** https://jxburros.github.io/CardSpoke/  
+**Deployed application:** <https://jxburros.github.io/CardSpoke/>
 **Observed version:** 0.18.1
 
 ## Executive assessment
@@ -80,18 +80,18 @@ Reviewed areas included:
 
 ### CS-101 — High — 0.18.1 can remain stuck behind the 0.18.0 service-worker cache
 
-**Evidence**
+#### Evidence
 
 - `package.json` and the deployed footer report 0.18.1.
 - `www/service-worker.js:8` still declares `cardspoke-app-shell-v0.18.0-public-1`.
 - `www/service-worker.js:64-72` serves non-navigation assets cache-first.
 - The 0.18.1 changes did not modify `service-worker.js`; its last functional change was the 0.18.0 cache bump.
 
-**Impact**
+#### Impact
 
 A user who previously installed the 0.18.0 worker can receive the new network-first `index.html` but the old cached `app.js`. Because the worker script bytes are unchanged, the browser has no reason to install a new worker and pre-cache a new namespace. That user can therefore remain on the release containing the PIN-dataset destruction, corrupt-store overwrite, plugin-boundary, and false-save-state defects that 0.18.1 was intended to fix.
 
-**Recommended fix**
+#### Recommended fix
 
 1. Change the cache namespace for every release, immediately to something such as `cardspoke-app-shell-v0.18.1-public-1`.
 2. Generate the namespace from `package.json` during build so it cannot drift.
@@ -101,18 +101,18 @@ A user who previously installed the 0.18.0 worker can receive the new network-fi
 
 ### CS-102 — Medium — The release browser QA suite is not installable or executed by CI
 
-**Evidence**
+#### Evidence
 
 - `package.json:13` exposes `npm run qa:browser`.
 - `scripts/browser-qa.mjs:34-45` says `playwright-core` is not part of normal installation and imports it anyway.
 - `package.json:43-48` does not declare Playwright.
 - `.github/workflows/pages.yml:32-44` runs install, unit tests, audit, build, and static smoke only; it never runs `qa:browser`.
 
-**Impact**
+#### Impact
 
 The strongest tests for the highest-risk behaviors—encrypted unlock, locked-write protection, corrupt-store quarantine, backup round trip, plugin consent, dataset switching, XSS, dialogs, and mobile overflow—are advisory rather than a reproducible release gate. A clean checkout cannot run the named QA script after `npm ci`, and Pages can deploy even if every browser scenario is broken.
 
-**Recommended fix**
+#### Recommended fix
 
 - Add a pinned Playwright dependency and a deterministic browser installation step.
 - Run `npm run qa:browser` in the QA job after build.
@@ -121,15 +121,15 @@ The strongest tests for the highest-risk behaviors—encrypted unlock, locked-wr
 
 ### CS-103 — Medium — Current regression tests inspect code text instead of proving several behaviors
 
-**Evidence**
+#### Evidence
 
 `tests/audit-regressions.test.js:94-149` validates major persistence and backup fixes by slicing `www/app.js` and looking for strings or regular-expression patterns. For example, it confirms that `storageWriteLock = true` and `showDatasetLockScreen` occur somewhere after `load()`, but it does not execute the locked-dataset flow.
 
-**Impact**
+#### Impact
 
 These tests can pass when the expected text exists in dead, unreachable, misordered, or semantically incorrect code. Conversely, harmless refactoring or minification changes can fail tests without changing behavior. The browser QA script contains the more meaningful tests, but CS-102 prevents it from protecting deployments.
 
-**Recommended fix**
+#### Recommended fix
 
 - Move persistence and import/export logic into testable modules with explicit dependencies.
 - Replace bundle-text assertions with behavioral unit/integration tests.
@@ -137,57 +137,57 @@ These tests can pass when the expected text exists in dead, unreachable, misorde
 
 ### CS-104 — Medium — The custom Vite fusion transform remains a high-fragility build component
 
-**Evidence**
+#### Evidence
 
 `vite.config.js:52-180` constructs one virtual module by stripping imports/exports with regular expressions, tracking declaration names, and removing duplicate functions using a character-level brace counter. The counter does not parse JavaScript syntax and therefore cannot distinguish braces in code from braces in strings, template literals, regular expressions, or comments.
 
-**Impact**
+#### Impact
 
 A valid source edit can be silently removed, mis-fused, or renamed during build. This risk is amplified because some tests enforce bundle text rather than runtime semantics. The system currently works, but it creates a narrow and surprising maintenance path.
 
-**Recommended fix**
+#### Recommended fix
 
 Gradually establish real ESM boundaries and explicit imports. In the interim, replace regex transforms with an AST-based transform and add source-to-bundle behavioral parity tests for every fused subsystem.
 
 ### CS-105 — Low — The optional PIN input is not programmatically associated with its visible label
 
-**Evidence**
+#### Evidence
 
 `www/src/data.js:1095-1113` creates a `<label>` and a separate `<input id="newDatasetPin">`, but the label has no `for="newDatasetPin"` and does not wrap the input. The `title` attribute is not a robust substitute for a form label.
 
-**Impact**
+#### Impact
 
 Screen-reader users may hear an inconsistently named password field, and clicking the visible label will not focus the control.
 
-**Recommended fix**
+#### Recommended fix
 
 Add `for: 'newDatasetPin'` to the label and an `aria-describedby` relationship to the help text. Audit the dynamically constructed dataset name and storage controls in the same pass.
 
 ### CS-106 — Low — PIN creation silently trims user-entered spaces and lacks confirmation
 
-**Evidence**
+#### Evidence
 
 `www/src/data.js:1124-1126` applies `.trim()` to the PIN and creates the encrypted dataset with one entry field.
 
-**Impact**
+#### Impact
 
 A user who intentionally includes leading or trailing spaces will later need to enter the trimmed value, not the value they believe they chose. A single typo is unrecoverable because the UI correctly warns that CardSpoke cannot recover a forgotten PIN.
 
-**Recommended fix**
+#### Recommended fix
 
 Do not normalize secrets unless the UI clearly declares the rule. Add confirmation, a reveal toggle, mismatch validation, and an explicit minimum-strength policy or clear statement that short PINs are convenience protection rather than strong security.
 
 ### CS-107 — Low — The dependency audit gate permits moderate advisories without visibility
 
-**Evidence**
+#### Evidence
 
 `.github/workflows/pages.yml:37-38` runs `npm audit --audit-level=high`.
 
-**Impact**
+#### Impact
 
 High and critical issues block release, which is sensible, but moderate issues can accumulate silently. For a project with a native toolchain and a security-sensitive local-data story, visibility still matters even when moderate advisories are accepted temporarily.
 
-**Recommended fix**
+#### Recommended fix
 
 Keep the high blocking threshold if desired, but generate and retain the full JSON audit report, summarize moderate findings in the workflow, and define a review/waiver process.
 
@@ -276,11 +276,11 @@ Recommended next step: add axe-core (or an equivalent engine) to browser QA, com
 
 ### Next hardening cycle
 
-5. Replace textual regression assertions with executable behaviors (CS-103).
-6. Begin retiring the regex-based fusion build (CS-104).
-7. Fix the dataset PIN label and PIN confirmation/normalization UX (CS-105/106).
-8. Add quota, crash-during-save, backup-round-trip, and 10,000-card benchmarks.
-9. Retain full audit output and review accepted moderate advisories (CS-107).
+1. Replace textual regression assertions with executable behaviors (CS-103).
+2. Begin retiring the regex-based fusion build (CS-104).
+3. Fix the dataset PIN label and PIN confirmation/normalization UX (CS-105/106).
+4. Add quota, crash-during-save, backup-round-trip, and 10,000-card benchmarks.
+5. Retain full audit output and review accepted moderate advisories (CS-107).
 
 ## Final conclusion
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "cardspoke",
   "version": "0.20.0",
   "description": "A lightweight, local-first card-based knowledge app",
-  "main": "index.js",
   "scripts": {
     "test": "uvu tests",
     "test:watch": "uvu tests --watch",

--- a/scripts/summarize-npm-audit.mjs
+++ b/scripts/summarize-npm-audit.mjs
@@ -1,0 +1,17 @@
+import { appendFileSync, readFileSync } from 'node:fs';
+
+const reportPath = process.argv[2] || 'npm-audit-report.json';
+const report = JSON.parse(readFileSync(reportPath, 'utf8').replace(/^\uFEFF/, ''));
+const vulnerabilities = report.metadata?.vulnerabilities || {};
+const summary = Object.entries(vulnerabilities)
+  .map(([severity, count]) => `${severity}: ${count}`)
+  .join(', ') || 'none';
+
+console.log('Vulnerabilities:', summary);
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  appendFileSync(
+    process.env.GITHUB_STEP_SUMMARY,
+    `### npm audit\n\nVulnerabilities: ${summary}\n`,
+  );
+}


### PR DESCRIPTION
## What changed

- fixed all remaining tracked markdownlint findings
- moved npm-audit summary generation out of inline shell code so `actionlint` passes
- removed the nonexistent `index.js` package entry point from this browser-only app

## Why

This resolves #334, #342, and #343 with narrow documentation, workflow, and package-metadata changes. The dependency audit remains a blocking release gate for high/critical vulnerabilities.

## Validation

- `npm test` — 403/403 passed
- `npm run build` — passed
- `npm run smoke` — passed
- `npm audit` — 0 vulnerabilities
- `markdownlint-cli2` — 0 issues across 46 files
- `actionlint` 1.7.12 — passed
- audit-summary helper executed against the current npm audit report