### PR TITLE
Document actual plugin system: 4 component overrides, no sandbox, real storage

### DIFF
--- a/.ai/qa.md
+++ b/.ai/qa.md
@@ -141,7 +141,7 @@ Record:
 Recommended additional command:
 
 ~~~bash
-npm audit --audit-level=critical
+npm audit --audit-level=high
 ~~~
 
 A nonzero audit result should be reported as a security finding, but it should not automatically block all other QA unless the vulnerability directly prevents the app from running.
@@ -310,14 +310,14 @@ Check for:
 
 ---
 
-## core.2 IndexedDB Storage Validation
+## core.2 Storage Persistence Validation
 
 Use browser dev tools or automation-accessible storage inspection.
 
 Validate:
 
-- Card graphs save to IndexedDB.
-- Relational/linked data saves to IndexedDB.
+- Card graphs save to the dataset's active driver — LocalStorage by default; check IndexedDB or the chosen local file only if the dataset's storage driver has been switched.
+- Relational/linked data saves to that same driver.
 - Data remains after page refresh.
 - Data remains after closing and reopening the app.
 - Deleted data is actually removed or correctly tombstoned, depending on app design.
@@ -843,6 +843,8 @@ Failure condition:
 `release` passes if:
 
 - All required `quick`, `core`, and `plugin` checks pass or are clearly documented.
+- `npm run smoke` (`scripts/static-smoke.mjs`) passes — required deployment gate.
+- `npm run qa:browser` (`scripts/browser-qa.mjs`) passes — required deployment gate.
 - Android Capacitor sync/open works in supported environment.
 - iOS Capacitor sync/open works in supported macOS environment or is correctly marked blocked on Windows.
 - 10,000+ card stress test does not catastrophically fail.
@@ -864,7 +866,6 @@ Includes:
 - Dependency install
 - Test runner
 - Vite build
-- Manual concatenation build
 - Dev server startup
 - Preview startup
 - `file://` standalone open test

--- a/.claude/skills/cardspoke-plugin-dev/SKILL.md
+++ b/.claude/skills/cardspoke-plugin-dev/SKILL.md
@@ -20,8 +20,8 @@ tested, reload-safe package.
 
 Authoritative references (read before/while working — they are the contract):
 
-- `docs/PLUGIN_SYSTEM.md` — full guide + complete `ctx` API reference.
-- `docs/PLUGIN_INVARIANTS.md` — what must not change; also the exact list of
+- `docs/architecture/PLUGIN_SYSTEM.md` — full guide + complete `ctx` API reference.
+- `docs/architecture/PLUGIN_INVARIANTS.md` — what must not change; also the exact list of
   hook names, permissions, selectors, and store schema you build against.
 - `sample-plugins/` — nine working packages (3 per layer) + `TEMPLATE.json`.
 - Bundled quick refs in this skill: [`references/ctx-api.md`](references/ctx-api.md),
@@ -135,10 +135,10 @@ enforces that every gallery entry points at a real package.
   survival — only string `js`/`teardownJs` are persisted. Module-form
   definitions with real functions are session-only dev tools.
 - Don't reach past `ctx.api.*` into app internals from a feature plugin; that
-  couples you to non-contract code (`docs/PLUGIN_INVARIANTS.md` lists what is
+  couples you to non-contract code (`docs/architecture/PLUGIN_INVARIANTS.md` lists what is
   actually stable).
 - Don't widen the plugin runtime to solve a single plugin's need — fix the
-  plugin. Runtime changes must honor `docs/PLUGIN_INVARIANTS.md` and update
+  plugin. Runtime changes must honor `docs/architecture/PLUGIN_INVARIANTS.md` and update
   its change checklist.
 - Keep themes CSS-only and use the documented CSS variables / `:root.dark`
   rather than hard-coding colors on core selectors.

--- a/.claude/skills/cardspoke-plugin-dev/references/checklist.md
+++ b/.claude/skills/cardspoke-plugin-dev/references/checklist.md
@@ -36,6 +36,6 @@ Tests / distribution
 
 Contract
 
-- [ ] No change to anything in `docs/PLUGIN_INVARIANTS.md`. If a runtime
+- [ ] No change to anything in `docs/architecture/PLUGIN_INVARIANTS.md`. If a runtime
       change was truly required, its change checklist was followed (docs,
       samples, tests, version bump).

--- a/.claude/skills/cardspoke-plugin-dev/references/ctx-api.md
+++ b/.claude/skills/cardspoke-plugin-dev/references/ctx-api.md
@@ -2,11 +2,11 @@
 
 The setup body runs as `function(ctx) { <your js> }`. Everything created via
 `ctx.api.*` is tracked and auto-removed on suspend/delete. Full detail in
-`docs/PLUGIN_SYSTEM.md`.
+`docs/architecture/PLUGIN_SYSTEM.md`.
 
 ```text
 ctx.modId            plugin id
-ctx.appVersion       '0.17.0'
+ctx.appVersion       '0.20.0'
 ctx.schemaVersion    4
 ctx.config           manifest.config (live; settings panel writes here)
 ctx.logger           .log / .info / .warn / .error   (prefixed console)

--- a/.claude/skills/cardspoke-plugin-dev/references/package-format.md
+++ b/.claude/skills/cardspoke-plugin-dev/references/package-format.md
@@ -1,6 +1,6 @@
 # Plugin package format quick reference
 
-A plugin is one JSON file. Canonical field docs: `docs/PLUGIN_SYSTEM.md`.
+A plugin is one JSON file. Canonical field docs: `docs/architecture/PLUGIN_SYSTEM.md`.
 
 ```json
 {

--- a/.claude/skills/cardspoke-plugin-review/SKILL.md
+++ b/.claude/skills/cardspoke-plugin-review/SKILL.md
@@ -12,8 +12,8 @@ description: >-
 # Reviewing / Debugging a CardSpoke Plugin
 
 Validate a package against the runtime contract and diagnose lifecycle
-failures. Ground truth: `docs/PLUGIN_INVARIANTS.md` and the runtime in
-`www/src/core/plugin-api.js`. Full behavior: `docs/PLUGIN_SYSTEM.md`.
+failures. Ground truth: `docs/architecture/PLUGIN_INVARIANTS.md` and the runtime in
+`www/src/core/plugin-api.js`. Full behavior: `docs/architecture/PLUGIN_SYSTEM.md`.
 
 ## Review pass (run top to bottom)
 
@@ -86,7 +86,7 @@ failures. Ground truth: `docs/PLUGIN_INVARIANTS.md` and the runtime in
 ## Invariant guardrails
 
 If a proposed fix changes runtime behavior rather than the plugin, check it
-against `docs/PLUGIN_INVARIANTS.md` first: the `window.CardSpoke` surface,
+against `docs/architecture/PLUGIN_INVARIANTS.md` first: the `window.CardSpoke` surface,
 boot order, host-bridge globals, `store.plugins` schema, permission names,
 middleware operation names, component names, and CSS selectors are contracts.
 Changing one means following that document's change checklist (documentation,

--- a/.codex/skills/cardspoke-mobile-shell-maintainer/SKILL.md
+++ b/.codex/skills/cardspoke-mobile-shell-maintainer/SKILL.md
@@ -11,7 +11,7 @@ description: "Use when working on CardSpoke Vite builds, Capacitor sync, Android
 
 ## Workflow
 
-- Treat Vite build output as authoritative; keep legacy concatenation fallback clearly secondary.
+- Treat `npm run build` (Vite, which fuses the app-layer modules internally) as the sole build path — there is no separate legacy concatenation script to maintain.
 - Run the relevant Capacitor sync command after web build changes that affect native shells.
 - Check local-first data ownership and mobile filesystem/preferences behavior before changing storage.
 - Keep Capacitor guide and release/version docs aligned with scripts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,23 @@ The format follows Keep a Changelog and the project uses semantic versioning whe
 
 ## [Unreleased]
 
+### Changed
+
+- Documented dataset encryption at rest (AES-GCM with a PBKDF2-derived key from the optional dataset PIN) in the storage/privacy and security policies, where the shipped feature had gone unmentioned.
+- Documented the Plugin Manager gallery request to `raw.githubusercontent.com` as the app's only outbound connection, including what it does and does not reveal.
+- Rewrote the architecture overview to match the implementation: no plugin sandbox or isolated contexts, the real storage-driver set with LocalStorage as the default, real bundle sizes, and honest priority tie-breaking rules.
+- Pointed security disclosures at private GitHub vulnerability reporting instead of public issues.
+- Added the `npm run smoke` and `npm run qa:browser` deployment gates to the test guide, developer guide, release checklist, and QA profile, which previously named only a subset of the checks CI enforces.
+- Annotated the 2026-07-10 audit report with the five findings resolved in v0.18.2 and the two still open.
+
 ### Fixed
 
+- Corrected the component registry documentation: the host queries only `Card`, `Header`, `Sidebar`, and `SearchBar`, and three of the four documented prop shapes were wrong. Examples and the TypeScript snippet now match `www/src/rendering.js`.
+- Corrected `PluginUtils` in `types/index.d.ts`, which declared six helpers that are not reachable from `ctx.utils` while omitting the twenty async helpers that are. Added the Header/Sidebar/SearchBar prop types and fixed registry return types.
+- Aligned `types/package.json` version and license with the root package (0.20.0, Apache-2.0).
+- Fixed plugin documentation paths in the agent skill files, which pointed at `docs/PLUGIN_SYSTEM.md` and `docs/PLUGIN_INVARIANTS.md` instead of their real `docs/architecture/` locations.
+- Corrected stale counts, dates, and claims: test suite baseline (33 files, 403 tests), Code of Conduct date, Capacitor CLI dependency location, export filename patterns, the nonexistent plugin dev-tools surface, and a "legacy concatenation build" that no longer exists.
+- Added the missing `analysis/` entry to the documentation index.
 - Removed the nonexistent Node package entry point from this browser-only package.
 - Moved dependency-audit summary generation into a checked-in Node script so the GitHub Pages workflow passes shell validation without changing the release gate.
 - Corrected the remaining markdownlint findings in the QA profile, plugin review skill, and historical audit report.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ CardSpoke is a local-first, card-based knowledge app. This documentation describ
 - [`guides/`](./guides/) — development, testing, Capacitor, offline-first, feature, and deviation guides.
 - [`policies/`](./policies/) — release, security, privacy, and community policies.
 - [`specifications/`](./specifications/) — product scope and longer-term specification material.
+- [`analysis/`](./analysis/) — functional reviews and analysis write-ups.
 - [`reports/`](./reports/) — dated historical audits; these record past findings and are not current release documentation.
 
 ## Documentation status and authority

--- a/docs/api/COMPONENT_REGISTRY.md
+++ b/docs/api/COMPONENT_REGISTRY.md
@@ -110,19 +110,26 @@ Clears all registered components from the registry. Used internally (e.g. during
 
 ## Standard Components
 
-The following core components are available for override:
+The host app queries exactly four component names. Registering any other name
+succeeds but has no effect, because nothing looks it up:
 
-| Component | Purpose | Props |
-|-----------|---------|-------|
-| `Card` | Card display | `{ id, title, body, tags, children }` |
-| `CardEditor` | Card editing form | `{ card, onSave, onCancel }` |
-| `Sidebar` | Left sidebar | `{ bookmarks, recentCards }` |
-| `SearchBar` | Search input | `{ onSearch, query }` |
-| `SearchResults` | Search results list | `{ results, query }` |
-| `TagList` | Tag display | `{ tags, onTagClick }` |
-| `Modal` | Modal dialog | `{ title, content, onClose }` |
-| `Toast` | Notification | `{ message, type }` |
-| `Menu` | Hamburger menu | `{ items }` |
+| Component | Purpose | Props | Queried at |
+|-----------|---------|-------|------------|
+| `Card` | Card tile in list/grid views | `{ card, isSelected, opts, onSelect }` | `www/src/rendering.js:181` |
+| `Header` | App header element | `{ header }` (the default header node) | `www/src/rendering.js:1155` |
+| `Sidebar` | Menu panel | `{ panel }` (the default panel node) | `www/src/rendering.js:1172` |
+| `SearchBar` | Search input wrapper | `{ wrapper }` (the default wrapper node) | `www/src/rendering.js:1189` |
+
+`Card` receives the card data itself: `props.card.title`, `props.card.tags`, and
+so on. `Header`, `Sidebar`, and `SearchBar` receive the DOM node the app was
+about to render, so an override can decorate or replace it.
+
+Each `render()` must return an `HTMLElement`. Returning anything else leaves the
+default rendering in place.
+
+> Names such as `CardEditor`, `SearchResults`, `TagList`, `Modal`, `Toast`, and
+> `Menu` are **not** override points today. Widening this list is a host-app
+> change, not a plugin-side one.
 
 ## Examples
 
@@ -131,20 +138,22 @@ The following core components are available for override:
 ```javascript
 // In plugin setup(ctx): ctx.api.ui.registerComponent('Card', { ... })
 ctx.api.ui.registerComponent('Card', {
-  render: (props) => {
-    const card = document.createElement('article');
-    card.className = 'enhanced-card';
-    card.setAttribute('data-card-id', props.id);
-    
+  // props = { card, isSelected, opts, onSelect }
+  render: ({ card, isSelected, onSelect }) => {
+    const el = document.createElement('article');
+    el.className = 'enhanced-card' + (isSelected ? ' is-selected' : '');
+    el.setAttribute('data-card-id', card.id);
+    el.addEventListener('click', onSelect);
+
     const header = document.createElement('header');
     const title = document.createElement('h2');
-    title.textContent = props.title || 'Untitled';
+    title.textContent = card.title || 'Untitled';
     header.appendChild(title);
-    
-    if (props.tags && props.tags.length > 0) {
+
+    if (card.tags && card.tags.length > 0) {
       const tagContainer = document.createElement('div');
       tagContainer.className = 'tag-container';
-      props.tags.forEach(tag => {
+      card.tags.forEach(tag => {
         const tagEl = document.createElement('span');
         tagEl.className = 'tag';
         tagEl.textContent = tag;
@@ -152,15 +161,15 @@ ctx.api.ui.registerComponent('Card', {
       });
       header.appendChild(tagContainer);
     }
-    
+
     const body = document.createElement('div');
     body.className = 'card-body';
-    body.textContent = props.body || '';
-    
-    card.appendChild(header);
-    card.appendChild(body);
-    
-    return card;
+    body.textContent = card.body || '';
+
+    el.appendChild(header);
+    el.appendChild(body);
+
+    return el;
   },
   priority: 50
 });
@@ -169,27 +178,20 @@ ctx.api.ui.registerComponent('Card', {
 ### Custom Search Bar
 
 ```javascript
+// props = { wrapper } — the default search wrapper the app was about to render.
+// There is no onSearch/query prop: decorate the real wrapper rather than
+// rebuilding the search input, so the app's own handlers keep working.
 ctx.api.ui.registerComponent('SearchBar', {
-  render: (props) => {
+  render: ({ wrapper }) => {
     const container = document.createElement('div');
     container.className = 'search-container';
-    
-    const input = document.createElement('input');
-    input.type = 'search';
-    input.placeholder = 'Search with AI...';
-    input.value = props.query || '';
-    input.oninput = (e) => {
-      if (props.onSearch) {
-        props.onSearch(e.target.value);
-      }
-    };
-    
+
     const icon = document.createElement('span');
     icon.textContent = '🔍';
-    
+
     container.appendChild(icon);
-    container.appendChild(input);
-    
+    container.appendChild(wrapper);
+
     return container;
   },
   priority: 75
@@ -220,7 +222,7 @@ ctx.api.ui.registerComponent('Card', {
     
     const timestamp = document.createElement('span');
     timestamp.className = 'timestamp';
-    timestamp.textContent = new Date(props.createdAt).toLocaleDateString();
+    timestamp.textContent = new Date(props.card.createdAt).toLocaleDateString();
     
     wrapper.appendChild(timestamp);
     wrapper.appendChild(originalElement);
@@ -245,18 +247,31 @@ When a component is requested:
 The core app checks the registry before rendering. This uses the internal `ComponentRegistry` module directly (not `window.CardSpoke`, which plugin code is confined to):
 
 ```javascript
-function renderCard(card) {
-  const CardComponent = ComponentRegistry.get('Card');
-  
-  if (CardComponent) {
-    // Use registered component
-    return CardComponent.render(card);
-  } else {
-    // Fallback to default rendering
-    return defaultRenderCard(card);
+// Simplified from www/src/rendering.js:181
+function renderCardTile(card, opts) {
+  const CustomCard = ComponentRegistry.get('Card');
+
+  if (CustomCard && typeof CustomCard.render === 'function') {
+    try {
+      const customEl = CustomCard.render({
+        card: card,
+        isSelected: opts.isSelected || false,
+        opts: opts,
+        onSelect: function() { goTo('read', { cardId: card.id }); }
+      });
+      // Anything that is not an HTMLElement is ignored and the default is used
+      if (customEl instanceof HTMLElement) return customEl;
+    } catch (err) {
+      console.warn('[ComponentRegistry] Custom Card render failed, using default:', err);
+    }
   }
+
+  return defaultRenderCardTile(card, opts);
 }
 ```
+
+A throwing or non-`HTMLElement`-returning override never breaks the app: the
+host catches it, warns, and falls back to the default rendering.
 
 ## Integration with Plugin API
 
@@ -285,19 +300,26 @@ ctx.api.ui.registerComponent('Card', {
 
 Using type definitions from the repository:
 
-```typescript
-/// <reference path="path/to/CardSpoke/types/index.d.ts" />
+The declarations are top-level named exports — there is no `CardSpoke` namespace
+type. Import them from the `types/` directory:
 
-const MyCard: CardSpoke.Component = {
-  render: (props: CardSpoke.CardProps) => {
-    // TypeScript knows props shape
-    return element;
+```typescript
+import type { Component, CardComponentProps } from './path/to/CardSpoke/types';
+
+const MyCard: Component = {
+  render: (props: CardComponentProps) => {
+    const el = document.createElement('article');
+    el.textContent = props.card.title;
+    return el;
   },
   priority: 50
 };
 
 ctx.api.ui.registerComponent('Card', MyCard);
 ```
+
+`HeaderComponentProps`, `SidebarComponentProps`, and `SearchBarComponentProps`
+are declared for the other three override points.
 
 **Note:** The `@cardspoke/core` package is not currently published to npm. Reference the type definitions directly from the `types/` directory in the repository.
 

--- a/docs/api/PLUGIN_API.md
+++ b/docs/api/PLUGIN_API.md
@@ -139,13 +139,17 @@ const restore = ctx.api.ui.replace('#card-title', newElement);
 
 #### `ctx.api.ui.registerComponent(name, component)`
 
-Register a UI component.
+Register a UI component override. The host queries only `Card`, `Header`,
+`Sidebar`, and `SearchBar`; `render()` must return an `HTMLElement` or the
+default rendering is kept. See
+[Component Registry](./COMPONENT_REGISTRY.md) for each component's props.
 
 ```javascript
+// Card props: { card, isSelected, opts, onSelect }
 ctx.api.ui.registerComponent('Card', {
   render: (props) => {
     const el = document.createElement('div');
-    el.textContent = props.title;
+    el.textContent = props.card.title;
     return el;
   },
   priority: 10

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -34,10 +34,10 @@
 │  ┌────────────────────────────────────────────────────────────┐   │
 │  │            🔌 Plugin Manager                               │   │
 │  │  ┌────────────────────────────────────────────────────┐   │   │
-│  │  │  Active Plugins (Isolated Contexts)               │   │   │
+│  │  │  Active Plugins (No Sandbox, Page Realm)          │   │   │
 │  │  │  ┌──────────────┬──────────────┬──────────────┐  │   │   │
 │  │  │  │   Plugin 1   │   Plugin 2   │   Plugin 3   │  │   │   │
-│  │  │  │   Context    │   Context    │   Context    │  │   │   │
+│  │  │  │  page realm  │  page realm  │  page realm  │  │   │   │
 │  │  │  └──────────────┴──────────────┴──────────────┘  │   │   │
 │  │  └────────────────────────────────────────────────────┘   │   │
 │  └────────────────────────────────────────────────────────────┘   │
@@ -53,15 +53,15 @@
 │  │            💾 Storage Driver Registry                      │   │
 │  │  ┌────────────────────────────────────────────────────┐   │   │
 │  │  │  Available Drivers                                 │   │   │
-│  │  │  • IndexedDB (default) ✓                          │   │   │
-│  │  │  • LocalStorage                                   │   │   │
-│  │  │  • Custom Cloud Driver (plugin)                   │   │   │
-│  │  │  • Git-based Driver (plugin)                      │   │   │
+│  │  │  • LocalStorage (default)                         │   │   │
+│  │  │  • IndexedDB (opt-in, per dataset)                │   │   │
+│  │  │  • Local File (File System Access API)            │   │   │
+│  │  │  • Custom drivers: registry only, unused          │   │   │
 │  │  └────────────────────────────────────────────────────┘   │   │
 │  └────────────────────────────────────────────────────────────┘   │
 │                                                                      │
 │  ┌────────────────────────────────────────────────────────────┐   │
-│  │            🛠️  Plugin API (Sandboxed)                      │   │
+│  │            🛠️  Plugin API (Full Trust)                     │   │
 │  │  ┌──────────────────┬──────────────────┐                  │   │
 │  │  │   ctx.api.ui     │   ctx.api.data   │                  │   │
 │  │  │   • inject()     │   • getCard()    │                  │   │
@@ -110,7 +110,7 @@ Logger Middleware (priority: -100)
     ├─ Logs the operation
     └─ Calls next()
     ↓
-Plugin.notifyDataUpdate({ type: 'create', card })
+Plugin.notifyDataUpdate({ type: 'card.create', cardId, card })
     ↓
 Plugins receive update via ctx.api.data.onUpdate()
     ↓
@@ -133,7 +133,7 @@ Components re-render via Component Registry
                      ↓
 ┌────────────────────────────────────────────────┐
 │              Plugin Activation                  │
-│  1. Create isolated context                    │
+│  1. Create plugin context (ctx)                │
 │  2. Apply CSS                                  │
 │  3. Call setup(ctx)                            │
 │  4. Track resources                            │
@@ -189,39 +189,57 @@ Component Request: "Card"
 
 ### 2. Priority-Based Resolution
 
-- **Middleware**: Higher priority runs first
-- **Components**: Higher priority overrides lower
-- **Deterministic**: Same priority = last registered wins
+- **Middleware**: Higher priority runs first. On a priority tie the sort is
+  stable, so the *first* registered runs first; a conflict warning is logged
+- **Components**: Higher priority overrides lower. On a priority tie the *last*
+  registered wins (the earlier registration is replaced) and a conflict warning
+  is logged. A lower-priority registration is rejected outright
 
 ### 3. Resource Management
 
-- **Automatic Tracking**: All resources tracked via plugin context
-- **Clean Unload**: Resources removed on plugin disable
-- **No Leaks**: WeakMap/WeakSet prevent memory leaks
+- **Automatic Tracking**: DOM nodes, listeners, styles, component overrides, and
+  middleware registered through `ctx` are recorded per plugin
+- **Clean Unload**: Tracked resources are removed on plugin disable/suspend
+- **Best-effort, not enforced**: cleanup covers what a plugin does *through the
+  `ctx` API*. A plugin that touches `document` directly is responsible for its
+  own teardown, and anything it leaves behind survives suspend
 
 ### 4. Security Layers
 
-- **Sandboxing**: Isolated plugin contexts
-- **Permissions**: Explicit capability model
-- **Validation**: Middleware can validate operations
-- **Namespacing**: Storage automatically isolated
+There is **no sandbox**. Plugin JavaScript is compiled with `new Function` and
+runs on the main thread in the page realm, with full reach over `window`,
+`document`, storage, and the network. The layers below manage *trust and
+expectations*, not isolation — see
+[Security & Safety](../policies/SECURITY_AND_SAFETY.md) for the full trust model.
 
-### 5. Backward Compatibility
+- **Full-trust consent**: any plugin shipping JavaScript requires explicit user
+  acceptance before it runs; CSS-only themes are the only auto-enabled layer
+- **Permissions**: a compatibility and UX contract that scopes what the
+  supported `ctx` API offers a well-behaved plugin — **not** a security boundary
+- **Risk labels**: `SAFE` / `LOW` / `HIGH` badges set expectations in the Plugin
+  Manager
+- **Safe Mode**: `?safemode` registers plugins without executing any of them
+- **Validation**: manifest, size, and footgun screening before registration
+- **Namespacing**: plugin storage keys are prefixed `plugin_<pluginId>_`, which
+  organizes data — it does not prevent one plugin from reading another's keys
 
-- **Bridge Layer**: Translates legacy calls
-- **Dual Support**: Both systems coexist
-- **Gradual Migration**: No forced upgrades
-- **Zero Breaking**: All existing plugins work
+### 5. Compatibility
+
+- **Schema gating**: plugins declare schema compatibility and are blocked on
+  incompatible schema versions
+- **Legacy-format tolerance**: plugin entries without a modern definition are
+  recognized and reported rather than crashing the registry
+- **Gradual Migration**: no forced upgrades within a schema version
 
 ## Technology Stack
 
 ```text
 ┌─────────────────────────────────────────┐
 │          Development Layer              │
-│  • TypeScript definitions               │
+│  • TypeScript definitions (types/)      │
 │  • Vite build system                    │
-│  • ES modules support                   │
-│  • Hot module replacement               │
+│  • ES modules in www/src/               │
+│  • uvu test suite                       │
 └─────────────────────────────────────────┘
               ↓
 ┌─────────────────────────────────────────┐
@@ -252,29 +270,44 @@ Component Request: "Card"
 
 ## Size Impact
 
-| Component | Size (minified) | Size (gzipped) |
-|-----------|----------------|----------------|
-| Middleware | ~3 KB | ~1.2 KB |
-| Component Registry | ~2 KB | ~0.8 KB |
-| Plugin API | ~6 KB | ~2.5 KB |
-| Storage Registry | ~1.5 KB | ~0.6 KB |
-| Permissions | ~2.5 KB | ~1 KB |
-| **Total New Code** | **~15 KB** | **~6 KB** |
+Everything under `www/src/` is fused by Vite into the single `www/app.js` the app
+ships, so per-module *minified* sizes are not separable after the build. The
+figures below are source sizes of the plugin-runtime modules, measured at 0.20.0:
 
-## Conclusion
+| Module (`www/src/core/`) | Source size |
+|--------------------------|-------------|
+| `plugin-api.js` | ~52 KB |
+| `permissions.js` | ~14 KB |
+| `plugin-validator.js` | ~8 KB |
+| `middleware.js` | ~6 KB |
+| `global-api.js` | ~4.4 KB |
+| `dataset-crypto.js` | ~4.1 KB |
+| `component-registry.js` | ~4.1 KB |
+| `storage-driver-registry.js` | ~3.4 KB |
+| `migrations.js` | ~2.6 KB |
+| **Total plugin runtime (source)** | **~98 KB** |
 
-The new architecture provides:
+Shipped bundle: `www/app.js` is ~391 KB raw, ~79 KB gzipped. Re-measure with
+`ls -l www/app.js` and `gzip -c www/app.js | wc -c` rather than trusting these
+numbers after significant changes.
 
-- ✅ Modern plugin development experience
-- ✅ Enterprise-grade security and isolation
-- ✅ Type safety and developer tooling
-- ✅ Pluggable storage and UI components
-- ✅ Perfect backward compatibility
-- ✅ Minimal performance overhead
+## Summary
 
-While maintaining:
+What this architecture provides:
 
-- ✅ Simple API for basic plugins
-- ✅ Local-first data model
-- ✅ Lightweight core bundle
-- ✅ File:// protocol support
+- A documented plugin API with middleware hooks and component overrides
+- Consent, risk labeling, and Safe Mode around full-trust plugin code
+- TypeScript definitions under `types/` for plugin authors
+- Pluggable storage drivers (LocalStorage, IndexedDB, Local File)
+- A local-first data model with no accounts, hosted sync, or telemetry
+- A single-bundle app that loads without a build step at runtime
+
+What it explicitly does **not** provide:
+
+- Plugin isolation or sandboxing of any kind
+- A security boundary from the `permissions` array
+- Cloud storage drivers or remote sync
+- Guaranteed cleanup of plugin side effects made outside the `ctx` API
+
+The bundled `www/app.js` path also works from `file://`; the service worker,
+offline caching, and the plugin gallery fetch require an HTTP origin.

--- a/docs/guides/DEVELOPER_GUIDE.md
+++ b/docs/guides/DEVELOPER_GUIDE.md
@@ -102,7 +102,7 @@ Do not add OS-specific shells, alternate app suites, typed-card domain systems, 
 
 - Update changelog and metadata for every public release.
 - Keep README, feature docs, and first-public-scope docs aligned.
-- Run `npm run build` and `npm test` before release.
+- Run `npm run build`, `npm test`, `npm run smoke`, and `npm run qa:browser` before release — the same gates `.github/workflows/pages.yml` enforces, alongside `npm audit --audit-level=high`.
 - Confirm `www/index.html` + `www/app.js` + `www/styles.css` can load locally.
 - Clearly mark mobile builds as experimental until platform hardening is complete.
 

--- a/docs/guides/DEVIATION_GUIDE.md
+++ b/docs/guides/DEVIATION_GUIDE.md
@@ -9,7 +9,7 @@ A Deviation is any fork or derivative build of CardSpoke. Use this guide to stay
 
 ## Mandatory Metadata
 
-Include the required metadata block for Deviations (see [Plugin System](../architecture/PLUGIN_SYSTEM.md)) with the appropriate manifest fields.
+Include the Deviation notice and credit block from the Required Notice Template below. If your Deviation also ships a plugin package, follow the manifest field requirements in [Plugin System](../architecture/PLUGIN_SYSTEM.md).
 
 ## Licenses & Attribution
 
@@ -31,7 +31,7 @@ Include the required metadata block for Deviations (see [Plugin System](../archi
 ## Safety & Data
 
 - Respect the local-first model; do not collect or transmit data without opt-in.
-- Provide migration and rollback instructions if you diverge from core schemas. Note how you handle exports created by the core (JSON/CSV/Markdown/TXT files named `cardspoke-{type}-{timestamp}.{ext}`, e.g. `cardspoke-instance-1719936000000.json`) and whether your build can import/export them without loss.
+- Provide migration and rollback instructions if you diverge from core schemas. Note how you handle exports created by the core — JSON exports are named `cardspoke-{type}-{timestamp}.json` (e.g. `cardspoke-instance-1719936000000.json`), while CSV/Markdown/TXT exports are named `cardspoke-{YYYY-MM-DD}.{ext}` with no type segment — and whether your build can import/export them without loss.
 
 ## Required Notice Template
 

--- a/docs/guides/FEATURES.md
+++ b/docs/guides/FEATURES.md
@@ -105,7 +105,7 @@ This catalog describes the current public CardSpoke app scope: the main local-fi
 - **Risk assessment:** Risk scoring based on layer and code analysis.
 - **Metadata transparency:** Plugins declare name, version, author, description, layer, compatibility, and permissions.
 - **TypeScript support:** Type definitions available in `types/` for plugin development.
-- **Dev tools:** Inspect plugins, hook stats, and error logs.
+- **Plugin introspection:** Inspect installed plugins with `Plugin.get(id)` and `Plugin.list()`; setup/teardown errors surface as toasts and console warnings. There is no `Plugin.devTools` object or hook-statistics view.
 
 ## Accessibility Features
 

--- a/docs/guides/README.CAPACITOR.md
+++ b/docs/guides/README.CAPACITOR.md
@@ -5,7 +5,7 @@ This guide covers platform prerequisites and workflows for building and running 
 ## Prerequisites
 
 - Node 18+
-- Capacitor CLI (`npx cap` via project devDependencies)
+- Capacitor CLI (`npx cap`, via the `@capacitor/cli` project dependency)
 - Android: Android Studio, Android SDK + platform tools, Java 17+
 - iOS: Xcode, CocoaPods, iOS device/simulator provisioning
 - Optional: platform-specific signing assets for release builds (Android keystore + iOS signing certificate/profile).

--- a/docs/guides/TEST_GUIDE.md
+++ b/docs/guides/TEST_GUIDE.md
@@ -16,6 +16,13 @@ Watch mode:
 npm run test:watch
 ```
 
+Release gates (also enforced by CI before any deploy):
+
+```bash
+npm run smoke        # static release checks (scripts/static-smoke.mjs)
+npm run qa:browser   # Playwright end-to-end release QA (scripts/browser-qa.mjs)
+```
+
 ## Test Scope
 
 Tests should cover the main CardSpoke app and the plugin runtime.

--- a/docs/policies/CODE_OF_CONDUCT.md
+++ b/docs/policies/CODE_OF_CONDUCT.md
@@ -90,4 +90,4 @@ We're all here to build something great together. Let's make CardSpoke a welcomi
 
 ---
 
-Last updated: 2025-11-27
+Last updated: 2026-05-07

--- a/docs/policies/RELEASE_AND_VERSIONING.md
+++ b/docs/policies/RELEASE_AND_VERSIONING.md
@@ -39,11 +39,22 @@ Those items require a separate future-version scope or another repository.
 - Verify plugin compatibility and note known incompatibilities.
 - Run `npm run build`.
 - Run `npm test`.
+- Run `npm run smoke` (static release checks: version consistency, CSP, bundle sanity).
+- Run `npm run qa:browser` (Playwright end-to-end release QA).
+- Run `npm audit --audit-level=high` (the level CI enforces).
 - Confirm `www/index.html`, `www/app.js`, and `www/styles.css` still open locally after build.
 - Confirm import/export smoke tests with a real dataset.
 - Confirm Plugin Manager install, enable, suspend, delete, and Safe Mode flows.
 - Confirm README, Feature Catalog, and First Public Scope agree with the release.
 - Tag release with version and schemaVersion.
+
+> The four automated checks above are the same gates `.github/workflows/pages.yml`
+> enforces before a Pages deploy; a red QA job deploys nothing.
+>
+> **Gap to close before the public release:** no git tags exist in this
+> repository, even though 0.18.0 through 0.20.0 have shipped. The tagging step
+> above is policy, not current practice. Either start tagging (and backfill the
+> shipped versions) or drop the step so the policy matches reality.
 
 ## Release Checklist (Plugin)
 

--- a/docs/policies/SECURITY_AND_SAFETY.md
+++ b/docs/policies/SECURITY_AND_SAFETY.md
@@ -29,15 +29,28 @@ This guide outlines expectations for secure, transparent, and user-respecting be
   - **Web**: The public app holds no credentials — there are no cloud storage drivers, no OAuth flows, and no hosted sync
   - **Desktop**: Consider using OS-level credential managers when available
 - Encrypt sensitive exports when feasible; document algorithms and key handling.
-  - Current exports are unencrypted JSON. For sensitive data, users should encrypt exports manually
-  - Future consideration: Add password-protected export option using Web Crypto API (AES-GCM)
+  - **Shipped:** datasets can be PIN-protected at rest — AES-GCM with a PBKDF2
+    (250,000 iterations) key derived from the PIN, persisted as a JSON envelope
+    that never contains the PIN. See `www/src/core/dataset-crypto.js` and
+    [Storage & Privacy](./STORAGE_AND_PRIVACY.md#dataset-encryption-at-rest)
+  - **Not covered:** user-initiated exports are still written as unencrypted
+    JSON/CSV/Markdown/TXT, including exports of a PIN-protected dataset. For
+    sensitive data, users should encrypt exports manually
+  - Future consideration: a password-protected export option reusing the same
+    envelope format
 - Minimize retention of logs; avoid logging user content unless necessary for explicit debug flows.
 
 ## Reporting & Response
 
-- Security disclosures should be reported via GitHub Issues: <https://github.com/jxburros/CardSpoke/issues>
-  - Mark issues as "Security" and they will be prioritized
-  - For critical vulnerabilities, contact the repository owner directly via GitHub
+- **Preferred (private):** report vulnerabilities through GitHub's private
+  vulnerability reporting on the repository's Security tab, so a fix can ship
+  before the issue is public. This must be enabled in repository settings before
+  the public release.
+- **Public issues** (<https://github.com/jxburros/CardSpoke/issues>) are
+  appropriate for hardening suggestions and already-public weaknesses — not for
+  an unpatched exploitable defect, since filing one discloses it to everyone.
+- No response-time commitment is offered: CardSpoke is maintained by a single
+  author, and reporters should assume best-effort handling.
 - Version advisories and clearly mark impacted versions/plugins.
 - Provide remediation steps, including how to disable plugins causing risk.
 
@@ -87,6 +100,14 @@ protocol) is tracked as future hardening work.
 The app ships a hardened CSP in `www/index.html`:
 
 - `default-src 'self'` — the app is self-contained; no third-party scripts, styles, or fonts load at startup.
+- `style-src 'self' 'unsafe-inline'` — inline styles are permitted because the app
+  builds elements with inline `style` attributes and theme plugins inject CSS
+  text. Under the full-trust plugin model this adds no attack surface beyond what
+  a consented plugin already has, but it does mean CSS injection is not blocked
+  by the CSP; it is bounded instead by `img-src` and by the app never reflecting
+  user content into CSS-selectable attributes (see `img-src` below).
+- `font-src 'self'` and `worker-src 'self'` — fonts and workers load only from the
+  app's own origin.
 - `connect-src 'self' https://raw.githubusercontent.com` — the only permitted `fetch`/XHR destination beyond the app's own origin is the curated plugin gallery, and "Install from URL" only resolves gallery-hosted packages.
 - `img-src 'self' data: blob:` — images are limited to the app's own origin plus inline `data:`/`blob:` data; arbitrary remote (`https:`) image loads are blocked. This closes the CSS `url()` / image-beacon channel a malicious or user-accepted plugin could otherwise use to signal data out of the page. It is paired with the app never reflecting user content (card titles, tags) into CSS-selectable DOM `value` attributes, so plugin CSS attribute selectors cannot read card content either.
 - `script-src 'self' 'unsafe-eval'` — `'unsafe-eval'` is required by the plugin runtime, which compiles the `setup`/`teardown` functions of JSON plugin packages at install/enable time (see `www/src/core/plugin-api.js`). This is a deliberate, documented trade-off under the full-trust plugin model: consent dialogs, risk labels, and Safe Mode set expectations, and moving plugin execution into sandboxed workers/iframes is tracked as future hardening work.

--- a/docs/policies/STORAGE_AND_PRIVACY.md
+++ b/docs/policies/STORAGE_AND_PRIVACY.md
@@ -6,13 +6,41 @@ CardSpoke is local-first. Users own their data, and the app does not silently sy
 
 - **LocalStorage:** Lightweight configuration, session data, and feature toggles. Also the default driver for structured card content, relationships, histories, and plugin registries — datasets are namespaced and tracked with metadata (name, card counts, recent/bookmark counts, schema/app version) so multiple vaults can coexist.
 - **IndexedDB:** An optional, per-dataset storage driver users can select instead of LocalStorage for card content and relationships. Also used internally for Local File System handle persistence, unrelated to card storage.
+- **Local File (File System Access API):** An optional, per-dataset driver that writes the dataset to a file the user picks on their own disk. The file handle is persisted in IndexedDB so the app can reopen it; the file itself is never uploaded anywhere.
 - **Filesystem (via Capacitor Filesystem):** Optional for attachments or exports; only used when explicitly enabled.
-- **Off-device storage:** Not part of the public app. Google Drive, OneDrive, WebDAV, and other cloud targets are deferred to a possible future version; the shipped app contains no cloud storage drivers and makes no cloud connections. If cloud storage returns in the future, it must never be required for normal card creation, editing, reading, navigation, import, export, or local dataset switching.
+- **Off-device storage:** Not part of the public app. Google Drive, OneDrive, WebDAV, and other cloud targets are deferred to a possible future version; the shipped app contains no cloud storage drivers and never sends card data off the device. If cloud storage returns in the future, it must never be required for normal card creation, editing, reading, navigation, import, export, or local dataset switching.
+
+## Dataset Encryption at Rest
+
+Datasets can be PIN-protected. When a PIN is set, the dataset is persisted as an
+encrypted JSON envelope rather than plaintext:
+
+- **Cipher:** AES-GCM, with a key derived from the PIN via PBKDF2 (250,000
+  iterations) and a per-dataset random salt.
+- **The PIN is never stored** in any form — not in metadata, not alongside the
+  envelope. Unlocking re-derives the key from the PIN the user types, so a
+  forgotten PIN means the dataset cannot be recovered.
+- **Applies across backends:** switching a PIN-protected dataset to the
+  IndexedDB or Local File driver re-encrypts on the way out, so plaintext is
+  never written to the target backend.
+- **Not covered:** user-initiated exports are written in plaintext (see Backup &
+  Export Guidance below), and a PIN protects data at rest — it is not a
+  guarantee against someone with access to the unlocked, running app.
+
+Implementation: `www/src/core/dataset-crypto.js`.
 
 ## Default Behavior
 
 - No automatic cloud sync or telemetry.
 - No analytics or tracking beacons are built into the core.
+- **The one outbound connection.** Opening the Gallery tab in the Plugin Manager
+  fetches `https://raw.githubusercontent.com/jxburros/CardSpoke/main/sample-plugins/manifest.json`
+  to list curated sample plugins, and installing from that gallery downloads the
+  chosen package. Nothing is sent but the request itself — no card data, no
+  identifiers — but like any web request it does reveal the user's IP address and
+  approximate time of use to GitHub. Nothing fetches it unless the user opens
+  that tab; the rest of the app never reaches the network. This is the only host
+  permitted by the app's `connect-src` CSP directive.
 - Plugins must not transmit data off-device without explicit, informed consent.
 - Preferences stored under `cardspoke_*` keys (rich text, grid view, typography, high contrast, dev mode, active theme) stay on-device and are restored at startup.
 - Local saves are authoritative while the user edits. Remote sync may fail, be unavailable, or be pending without invalidating the local save. (The current public app has no remote sync at all; this rule binds any future off-device integration.)
@@ -28,14 +56,14 @@ CardSpoke is local-first. Users own their data, and the app does not silently sy
 ## User Controls
 
 - Provide clear settings to opt into any off-device storage/integration.
-- Offer data export/import paths (JSON or other agreed formats) to preserve portability. The UI exports datasets as JSON, CSV, Markdown, or TXT (named `cardspoke-export-*`), and maintains timestamped backups for rollback.
+- Offer data export/import paths (JSON or other agreed formats) to preserve portability. The UI exports datasets as JSON, CSV, Markdown, or TXT under `cardspoke-*` filenames (JSON as `cardspoke-<type>-<timestamp>.json`, e.g. `cardspoke-instance-1719936000000.json`; CSV/Markdown/TXT as `cardspoke-<YYYY-MM-DD>.<ext>`), and maintains timestamped backups for rollback.
 - Surface active plugins and their data-touching permissions.
 
 ## Security Considerations
 
 - Validate file types and sizes before writing to disk.
 - Avoid storing secrets in LocalStorage; prefer secure platform stores where available (Capacitor Preferences for non-sensitive app prefs, and OS-level secure stores/Keychain/Keystore for credentials when added).
-- Document any encryption used for local caches or exports.
+- Document any encryption used for local caches or exports (see Dataset Encryption at Rest above).
 - Do not cache user datasets in service-worker Cache Storage. Cache Storage should only hold app-shell assets such as HTML, CSS, JS, icons, and the manifest.
 
 ## Incident Response
@@ -47,4 +75,4 @@ CardSpoke is local-first. Users own their data, and the app does not silently sy
 
 - Recommended backup cadence: before major edits/imports/plugin installs, and at regular intervals for active datasets.
 - Supported backup/export formats in current app flows: JSON, CSV, Markdown, TXT.
-- Encryption-at-export is not built in yet; users handling sensitive data should encrypt exported files using trusted external tools before sharing or cloud sync.
+- Encryption-at-export is not built in yet. Note that this is separate from dataset encryption at rest: exporting a PIN-protected dataset writes plaintext. Users handling sensitive data should encrypt exported files using trusted external tools before sharing or cloud sync.

--- a/docs/reports/AUDIT_QA_2026-07-10.md
+++ b/docs/reports/AUDIT_QA_2026-07-10.md
@@ -6,6 +6,20 @@
 **Deployed application:** <https://jxburros.github.io/CardSpoke/>
 **Observed version:** 0.18.1
 
+> **Status as of 0.20.0 (2026-07-27):** this is a dated historical record; its
+> body is preserved as written on 2026-07-10. Five of the seven findings —
+> CS-101, CS-102, CS-105, CS-106, CS-107 — were resolved in v0.18.2 (commit
+> `c82a601`), including the service-worker update defect and the missing browser
+> QA gate that the assessment below calls the principal release risks. The
+> service-worker cache namespace is now rewritten from `package.json` on every
+> build and verified by `npm run smoke`, and `npm run qa:browser` is a required
+> deployment gate in `.github/workflows/pages.yml`.
+>
+> Still open: **CS-103** (bundle assertions in
+> `tests/audit-regressions.test.js` match on bundle text) and **CS-104** (the
+> character-level brace counter used by the Vite fusion transform in
+> `vite.config.js`).
+
 ## Executive assessment
 
 CardSpoke 0.18.1 is substantially safer and more release-ready than 0.18.0. The critical data-loss, corrupt-store overwrite, misleading save-state, backup-shape, plugin-consent, and modal-accessibility findings from the 2026-07-09 audit have concrete fixes and targeted regression coverage. The deployed HTML and JavaScript exactly match the reviewed repository files, and live create/save/reload plus hostile-text rendering passed.
@@ -78,7 +92,7 @@ Reviewed areas included:
 
 ## Open findings
 
-### CS-101 — High — 0.18.1 can remain stuck behind the 0.18.0 service-worker cache
+### CS-101 — High — 0.18.1 can remain stuck behind the 0.18.0 service-worker cache — RESOLVED in v0.18.2 (c82a601)
 
 #### Evidence
 
@@ -99,7 +113,7 @@ A user who previously installed the 0.18.0 worker can receive the new network-fi
 4. Consider stale-while-revalidate or network-first behavior for `app.js`, with atomic activation, so patch releases are not dependent solely on a manual string bump.
 5. Add an update test: install release N, populate the cache, serve release N+1, reload, and assert that N+1 code runs while user data remains intact.
 
-### CS-102 — Medium — The release browser QA suite is not installable or executed by CI
+### CS-102 — Medium — The release browser QA suite is not installable or executed by CI — RESOLVED in v0.18.2 (c82a601)
 
 #### Evidence
 
@@ -149,7 +163,7 @@ A valid source edit can be silently removed, mis-fused, or renamed during build.
 
 Gradually establish real ESM boundaries and explicit imports. In the interim, replace regex transforms with an AST-based transform and add source-to-bundle behavioral parity tests for every fused subsystem.
 
-### CS-105 — Low — The optional PIN input is not programmatically associated with its visible label
+### CS-105 — Low — The optional PIN input is not programmatically associated with its visible label — RESOLVED in v0.18.2 (c82a601)
 
 #### Evidence
 
@@ -163,7 +177,7 @@ Screen-reader users may hear an inconsistently named password field, and clickin
 
 Add `for: 'newDatasetPin'` to the label and an `aria-describedby` relationship to the help text. Audit the dynamically constructed dataset name and storage controls in the same pass.
 
-### CS-106 — Low — PIN creation silently trims user-entered spaces and lacks confirmation
+### CS-106 — Low — PIN creation silently trims user-entered spaces and lacks confirmation — RESOLVED in v0.18.2 (c82a601)
 
 #### Evidence
 
@@ -177,7 +191,7 @@ A user who intentionally includes leading or trailing spaces will later need to 
 
 Do not normalize secrets unless the UI clearly declares the rule. Add confirmation, a reveal toggle, mismatch validation, and an explicit minimum-strength policy or clear statement that short PINs are convenience protection rather than strong security.
 
-### CS-107 — Low — The dependency audit gate permits moderate advisories without visibility
+### CS-107 — Low — The dependency audit gate permits moderate advisories without visibility — RESOLVED in v0.18.2 (c82a601)
 
 #### Evidence
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,8 +15,8 @@ npm run test:watch
 ## Current Suite Status
 
 - Framework: [uvu](https://github.com/lukeed/uvu)
-- Test files: 26 (`*.test.js`)
-- Latest baseline: **347 / 347 passing** (`npm test`)
+- Test files: 33 (`*.test.js`)
+- Latest baseline: **403 / 403 passing** (`npm test`, verified at 0.20.0)
 
 ## What's Covered
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -17,7 +17,7 @@
 
 /**
  * CardSpoke Core Type Definitions
- * @version 0.17.0
+ * @version 0.20.0
  * @module @cardspoke/core
  */
 
@@ -221,10 +221,19 @@ export interface CardComponentProps {
   onSelect: () => void;
 }
 
-/** Props passed to a registered Sidebar component */
+/** Props passed to a registered Header component: the default header node */
+export interface HeaderComponentProps {
+  header: HTMLElement;
+}
+
+/** Props passed to a registered Sidebar component: the default menu panel node */
 export interface SidebarComponentProps {
-  cards: Card[];
-  selectedCardId: string | null;
+  panel: HTMLElement;
+}
+
+/** Props passed to a registered SearchBar component: the default wrapper node */
+export interface SearchBarComponentProps {
+  wrapper: HTMLElement;
 }
 
 export interface MiddlewareContext {
@@ -249,13 +258,31 @@ export interface Middleware {
   handler: MiddlewareFunction;
 }
 
+/**
+ * Async host helpers exposed as `ctx.utils` / `window.CardSpoke.utils`.
+ * Populated in www/src/storage.js — keep this in step with that block.
+ */
 export interface PluginUtils {
-  uid(): string;
-  debounce(func: Function, wait: number): Function;
-  escapeHtml(str: string): string;
-  normalizeTagInput(raw: string): string;
-  cloneCard(card: Card): Card;
-  highlightText(text: string, query: string): string;
+  createCard(data: Partial<Card>): Promise<{ id: string; card: Card }>;
+  updateCard(cardId: string, changes: Partial<Card>): Promise<boolean>;
+  getCard(cardId: string): Promise<Card | null>;
+  searchCards(query: string): Promise<Card[]>;
+  getTags(cardId: string): Promise<string[]>;
+  addTag(cardId: string, tag: string): Promise<boolean>;
+  removeTag(cardId: string, tag: string): Promise<boolean>;
+  setTags(cardId: string, tags: string[]): Promise<boolean>;
+  getAllTags(): Promise<string[]>;
+  showToast(message: string, type?: string, duration?: number): Promise<void>;
+  getDatasetMeta(): Promise<Record<string, any>>;
+  getAccessibilitySettings(): Promise<Record<string, any>>;
+  setTheme(theme: 'light' | 'dark'): Promise<boolean>;
+  getTheme(): Promise<string>;
+  setTypography(preset: string): Promise<boolean>;
+  getTypography(): Promise<string>;
+  setHighContrast(enabled: boolean): Promise<boolean>;
+  isHighContrast(): Promise<boolean>;
+  prefersReducedMotion(): Promise<boolean>;
+  getThemeVariables(): Promise<Record<string, any>>;
 }
 
 export interface StorageDriver {
@@ -373,8 +400,9 @@ export interface MiddlewareManager {
 }
 
 export interface ComponentRegistryClass {
-  register(name: string, component: Component, priority?: number): void;
-  unregister(name: string): void;
+  /** Returns false when a lower-priority registration is rejected. */
+  register(name: string, component: Component, priority?: number): boolean;
+  unregister(name: string): boolean;
   get(name: string): Component | undefined;
   resolve(name: string): Component | undefined;
   has(name: string): boolean;
@@ -384,7 +412,7 @@ export interface ComponentRegistryClass {
 
 export interface StorageDriverRegistryClass {
   register(name: string, driver: StorageDriver): void;
-  unregister(name: string): void;
+  unregister(name: string): boolean;
   get(name: string): StorageDriver | undefined;
   setActive(name: string): Promise<void>;
   getActive(): StorageDriver;

--- a/types/package.json
+++ b/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cardspoke/core",
-  "version": "0.17.0",
+  "version": "0.20.0",
   "description": "TypeScript type definitions for CardSpoke plugin development",
   "main": "index.d.ts",
   "types": "index.d.ts",
@@ -12,5 +12,5 @@
     "plugin"
   ],
   "author": "jxburros",
-  "license": "ISC"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
This PR corrects the plugin system documentation to match the shipped implementation, addressing a significant gap between what the docs claimed and what the code actually does.

## Summary

The documentation previously described an idealized plugin architecture with isolated contexts, sandboxing, and a broad set of overridable components. The actual implementation is simpler and more honest: plugins run in the page realm with full trust, only four UI components are queryable (`Card`, `Header`, `Sidebar`, `SearchBar`), and the storage layer defaults to LocalStorage with optional IndexedDB or Local File drivers.

## Key Changes

**Component Registry (`docs/api/COMPONENT_REGISTRY.md`)**
- Corrected the list of queryable components from 9 to 4 (`Card`, `Header`, `Sidebar`, `SearchBar`)
- Fixed all prop shapes to match `www/src/rendering.js`: `Card` receives `{ card, isSelected, opts, onSelect }`, not `{ id, title, body, tags }`; `Header`, `Sidebar`, and `SearchBar` receive the default DOM node, not custom data
- Updated examples to use correct prop destructuring and node decoration patterns
- Added line references to the actual query sites in the rendering code
- Clarified that returning non-`HTMLElement` values leaves default rendering in place
- Documented that only these four names are queried; registering others succeeds but has no effect

**Architecture Overview (`docs/architecture/OVERVIEW.md`)**
- Removed claims of "isolated contexts" and "sandboxing"; documented that plugins run in the page realm with no isolation
- Corrected storage driver list: LocalStorage is the default (not IndexedDB), with IndexedDB and Local File as opt-in per-dataset drivers
- Rewrote the security section to be honest about the full-trust model: no sandbox, no security boundary from permissions, but consent, risk labeling, and Safe Mode as trust mechanisms
- Updated priority tie-breaking rules to match actual behavior (middleware: stable sort, first wins; components: last registered wins, lower-priority rejected)
- Replaced idealized size figures with real source sizes of plugin-runtime modules
- Clarified resource cleanup covers only what goes through the `ctx` API, not direct `document` manipulation

**Type Definitions (`types/index.d.ts`)**
- Updated `HeaderComponentProps` and `SidebarComponentProps` to receive `{ header }` and `{ panel }` (the default nodes) instead of custom data
- Added `SearchBarComponentProps` with `{ wrapper }` signature
- Rewrote `PluginUtils` to document actual async helpers (card CRUD, tag ops, theme/accessibility settings) instead of utility functions
- Updated version to 0.20.0 and license to Apache-2.0

**Security & Storage Policies**
- Documented dataset encryption at rest (AES-GCM with PBKDF2-derived key from optional PIN) in `STORAGE_AND_PRIVACY.md`
- Noted the one outbound connection: Plugin Manager gallery fetch to `raw.githubusercontent.com`
- Updated vulnerability reporting guidance to prefer private GitHub security reporting over public issues
- Clarified that exports remain unencrypted even for PIN-protected datasets

**Test & Release Guidance**
- Added `npm run smoke` and `npm run qa:browser` as required deployment gates in test guide, release checklist, and QA profile
- Updated audit report with resolution status of findings from v0.18.2
- Corrected storage validation QA to check the active driver (LocalStorage by default) rather than assuming IndexedDB

**Plugin API Documentation (`docs/api/PLUGIN_API.md`)**
- Updated `registerComponent()` docs to clarify only 4 names are queried and `render()` must return `HTMLElement`
- Fixed example to use `props.card.title` instead of `props.title`

## Implementation Details

All changes are documentation-only; no runtime code was modified. The corrections align docs with the actual behavior in `www/src/rendering.js` (component queries), `www/src/core/dataset-crypto.js` (encryption), and `www/src/core/plugin-api.js` (plugin lifecycle). This closes a long-standing gap where the docs described an aspirational architecture rather than what shipped

https://claude.ai/code/session_0173Fw27TdP4bjy8rTg6r6pu